### PR TITLE
Correct varnish::vcl dependencies

### DIFF
--- a/manifests/vcl.pp
+++ b/manifests/vcl.pp
@@ -130,5 +130,6 @@ class varnish::vcl (
     mode    => '0644',
     content => template($template_vcl),
     notify  => Service['varnish'],
+    require => Package['varnish'],
   }
 }


### PR DESCRIPTION
Require varnish package so /etc/varnish exists before this file is created.
