### PR TITLE
Set custom conf_file_path for Oracle Linux

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,7 +5,7 @@ class varnish::params {
 
   # set Varnish conf location based on OS
   $conf_file_path = $::operatingsystem ? {
-    /(?i:Centos|RedHat)/      => '/etc/sysconfig/varnish',
-    default                   => '/etc/default/varnish',
+    /(?i:Centos|RedHat|OracleLinux)/  => '/etc/sysconfig/varnish',
+    default                           => '/etc/default/varnish',
   }
 }


### PR DESCRIPTION
In Oracle Linux, config file is located in /etc/sysconfig/varnish.
