### PR TITLE
403 with no selectors

### DIFF
--- a/manifests/vcl.pp
+++ b/manifests/vcl.pp
@@ -181,7 +181,7 @@ class varnish::vcl (
   create_resources(varnish::director,$directors)
 
   #Selectors
-  if $selectors {
+  if $selectors != {} {
     validate_hash($selectors)
     concat::fragment { "selectors-header":
       target => "${varnish::vcl::includedir}/backendselection.vcl",


### PR DESCRIPTION
I had to make the following change to make the varnish config work without any specified selectors. Otherwise, the defaultselectors file contained nothing except throwing a 403 error.
