### PR TITLE
Added logrealip attribute to vcl class

### DIFF
--- a/manifests/vcl.pp
+++ b/manifests/vcl.pp
@@ -46,6 +46,7 @@ class varnish::vcl (
   $static_cache_time = "5m",
   $gziptypes         = [ 'text/', 'application/xml', 'application/rss', 'application/xhtml', 'application/javascript', 'application/x-javascript' ],
   $template          = undef,
+  $logrealip         = false,
 ) {
 
   include varnish

--- a/templates/varnish-vcl.erb
+++ b/templates/varnish-vcl.erb
@@ -21,6 +21,13 @@ sub vcl_recv {
   # Default grace period
   set req.grace = <%= @defaultgrace %>;
 <%- end -%>
+<%- if @logrealip -%> 
+  if (req.http.X-Forwarded-For) {
+     std.log("RealIP:" + req.http.X-Forwarded-For); 
+  } else {
+     std.log("RealIP:" + client.ip); 
+  }
+<%- end -%>
 
   unset req.http.If-Modified-Since;
   unset req.http.If-None-Match; 


### PR DESCRIPTION
Added option to log to SHM the real IP address from the originating host. Useful when Varnish is behind another web server (like nginx for SSL offloading).
