### PR TITLE
Add Varnish 4 support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,4 +8,9 @@ class varnish::params {
     /(?i:Centos|RedHat|OracleLinux)/  => '/etc/sysconfig/varnish',
     default                           => '/etc/default/varnish',
   }
+
+  $version = $varnish::version ? {
+    /4\..*/ => 4,
+    default => 3,
+  }
 }

--- a/templates/varnish-conf.erb
+++ b/templates/varnish-conf.erb
@@ -75,7 +75,14 @@ DAEMON_OPTS="-a ${VARNISH_LISTEN_ADDRESS}:${VARNISH_LISTEN_PORT} \
              -f ${VARNISH_VCL_CONF} \
              -T ${VARNISH_ADMIN_LISTEN_ADDRESS}:${VARNISH_ADMIN_LISTEN_PORT} \
              -t ${VARNISH_TTL} \
-             -w ${VARNISH_MIN_THREADS},${VARNISH_MAX_THREADS},${VARNISH_THREAD_TIMEOUT} \
              -S ${VARNISH_SECRET_FILE} \
-             -s ${VARNISH_STORAGE}"
+             -s ${VARNISH_STORAGE} \
+<% if scope.lookupvar('varnish::params::version') == '4' -%>
+             -p thread_pool_min=${VARNISH_MIN_THREADS} \
+             -p thread_pool_max=${VARNISH_MAX_THREADS} \
+             -p thread_pool_timeout=${VARNISH_THREAD_TIMEOUT}"
+<% else -%>
+             -w ${VARNISH_MIN_THREADS},${VARNISH_MAX_THREADS},${VARNISH_THREAD_TIMEOUT}"
+<% end %>
+
 


### PR DESCRIPTION
The Varnish configuration template that ships with this module contains a `-w` flag, which no longer works with Varnish 4. This PR adds first steps towards Varnish 4 support by adding version detection and fixing the configuration template.
