### PR TITLE
Don't add ACL when hosts array is empty

### DIFF
--- a/manifests/acl.pp
+++ b/manifests/acl.pp
@@ -3,12 +3,14 @@ define varnish::acl(
   $hosts,
 ) {
 
-  validate_re($title,'^[A-Za-z0-9_]*$', "Invalid characters in ACL name ${title}. Only letters, numbers and underscore are allowed.")
+  # Varnish does not allow empty ACLs
+  if size($hosts) > 0 {
+    validate_re($title,'^[A-Za-z0-9_]*$', "Invalid characters in ACL name ${title}. Only letters, numbers and underscore are allowed.")
 
-  concat::fragment { "${title}-acl":
-    target  => "${varnish::vcl::includedir}/acls.vcl",
-    content => template('varnish/includes/acls.vcl.erb'),
-    order   => '02',
+    concat::fragment { "${title}-acl":
+      target  => "${varnish::vcl::includedir}/acls.vcl",
+      content => template('varnish/includes/acls.vcl.erb'),
+      order   => '02',
+    }
   }
-
 }


### PR DESCRIPTION
Varnish doesn't allow empty ACLs. Currently, the module adds two empty ACLs by default: `blockedips` and `purge`. This PR is one possible way of solving this problem: by ignoring any ACLs that contain no hosts. 

Alternatively, we can change the `$default_acls` in `vcl.pp` to only add `blockedips` and `purge` when  `$purgeips` and `$blockedips` contain at least one element. 

Which solution do you prefer?
