### PR TITLE
Fix resource ordering

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -20,7 +20,10 @@
 class varnish::install (
   $add_repo = true
 ) {
-  class { 'varnish::repo': enable => $add_repo }
+  class { 'varnish::repo':
+    enable => $add_repo,
+    before => Package['varnish'],
+  }
 
   # varnish package
   package { 'varnish':

--- a/manifests/vcl.pp
+++ b/manifests/vcl.pp
@@ -93,7 +93,8 @@ class varnish::vcl (
 
   if $template == undef or $manage_includes {
     file { $includedir:
-      ensure => directory,
+      ensure  => directory,
+      require => Package['varnish'],
     }
     $includefiles = ['probes', 'backends', 'directors', 'acls', 'backendselection', 'waf']
     includefile { $includefiles: }


### PR DESCRIPTION
Make sure the repo is installed before installing the package (so the package is not accidentally installed from the OS repo) and Varnish is installed before trying to create files in the `/etc/varnish` directory.
