### PR TITLE
Fix syntax error when calling varnish::install and other minor fixes

### DIFF
--- a/manifests/firewall.pp
+++ b/manifests/firewall.pp
@@ -1,6 +1,6 @@
 # Class varnish::firewall
 #
-# Uses puppetlabs/firewall module to open port 80
+# Uses puppetlabs/firewall module to open varnish listen port
 #
 class varnish::firewall (
 	$manage_firewall     = false,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -72,13 +72,9 @@ class varnish (
 
   # install Varnish
   class {'varnish::install':
-    add_repo            => $add_repo
-    manage_firewall     => $manage_firewall
-    varnish_listen_port => $varnish_listen_port
-  }
-
-  # add firewall rule for port 80
-  class {'varnish::firewall':
+    add_repo            => $add_repo,
+    manage_firewall     => $manage_firewall,
+    varnish_listen_port => $varnish_listen_port,
   }
 
   # enable Varnish service

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -20,7 +20,7 @@
 class varnish::install (
   $add_repo = true,
   $manage_firewall = false,
-  $varnish_listen_port
+  $varnish_listen_port = '6081',
 ) {
   class { 'varnish::repo':
     enable => $add_repo,
@@ -28,7 +28,7 @@ class varnish::install (
   }
 
   class { 'varnish::firewall':
-	  enable              => $manage_firewall,
+	  manage_firewall     => $manage_firewall,
 	  varnish_listen_port => $varnish_listen_port,
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,77 @@
+{
+  "author": "Max Horlanchuk \u003cmax.horlanchuk@gmail.com\u003e",
+  "checksums": {
+    "manifests/vcl.pp": "bfd640f7bc97b6feb1f397d494345615",
+    "manifests/install.pp": "5ff4badd2547580edc9f3ffb5a7a6d75",
+    "manifests/firewall.pp": "104132d85d30568eabdbeccda5be1861",
+    "templates/includes/waf.vcl.erb": "4d0c1f0b84754c10e2c4bc16cc2c5ebc",
+    "manifests/service.pp": "674282ae27f9ef91bdfbbe0435c46a6f",
+    "spec/spec.opts": "c407193b3d9028941ef59edd114f5968",
+    "tests/params.pp": "44bbfd219cfc0312ed11d04c1964ee7c",
+    "tests/vcl_backends_probes_directors.pp": "6e11ebddd4f0ea6dcbf977e33bc8400d",
+    "manifests/selector.pp": "05f10c4d0ee32c1bf8324f87dbf600b8",
+    "LICENSE": "0e5ccf641e613489e66aa98271dbe798",
+    "manifests/params.pp": "3eb1462d20635b45c1bacf320259582d",
+    "tests/vcl_backends.pp": "b5001d566513c785073c59e1e97cf4f4",
+    "templates/includes/probes.vcl.erb": "c00cad6963b59c55fc6e96bb1aebaa6a",
+    "manifests/shmlog.pp": "f9fa91603c22c294d2212318fd7dc76d",
+    "manifests/init.pp": "ba4f4c49dce2bb43171e264e2694c2ec",
+    "templates/includes/acls.vcl.erb": "d11e73cf5585647251e54df36a3eb651",
+    "templates/varnish-conf.erb": "4ad3a801b71cb870b6c8b76826bcf8f5",
+    "manifests/director.pp": "329ee6017501cf95576936cf34f90803",
+    "README.md": "9acc98b6a6b3509b18562db6a0b46cc5",
+    "templates/includes/backendselection.vcl.erb": "6d51032e79b5961ae1d9951e6471a7fd",
+    "spec/classes/varnish_spec.rb": "07c2ed97a6fcf9a4d36a9952e022cdd2",
+    "Rakefile": "6ed92610a3ff19c0c68b30e19b3e33c7",
+    "templates/varnishncsa-default.erb": "a888ff3759cc6be86b2379efc6e2150e",
+    "manifests/probe.pp": "859611eff54aeeaeed2167e373033cf0",
+    "manifests/repo.pp": "d6d59e146e139253c0b22ac4a8e7b312",
+    "tests/vcl_class_config_by_params.pp": "b8aa910858fcbcc2dc69b26cf259bb8f",
+    ".fixtures.yml": "b5da77f69fe13d5f5d1b9844f81f65d1",
+    "tests/shmlog.pp": "a58e028bc35dc260497b18e4c8c45276",
+    "manifests/acl.pp": "5543e2d9e4609aa62e61c61e4999b2ce",
+    "spec/classes/varnish_shmlog_spec.rb": "8f8d0450a45876278462ab00c45bb77d",
+    "spec/classes/varnish_service_spec.rb": "6592aec8f909ea20d9f35b0747974676",
+    "templates/includes/directors.vcl.erb": "f351d11152c91e951e9965e2b60e8337",
+    "spec/classes/varnish_vcl_spec.rb": "97252f2625f0664b7b84ce64302779ec",
+    "spec/classes/varnish_repo_spec.rb": "39172e547137b8d0b5ea0488db2987a1",
+    "templates/includes/backends.vcl.erb": "bf40fc03f0f951bf7f9dd9a8a44281d9",
+    "spec/spec_helper.rb": "2598e0d4faa8b1c4ddb20f352e54811e",
+    "spec/defines/acl_spec.rb": "df6b7cbe081bb05b67ae4cca91ae5b41",
+    "tests/service.pp": "47c7272262254406fcc0acc74cd40c93",
+    "manifests/ncsa.pp": "a890fd239f5def8b207de841dc008285",
+    "spec/classes/varnish_ncsa_spec.rb": "474af6de19217fc8736d60a745ab4dfd",
+    "tests/vcl_backend_default.pp": "e9d1d48d9c872d8037ea892522bbdb51",
+    "tests/install.pp": "3d236f7f5e7bac59fde358492ee58b3b",
+    "Gemfile": "cc73c011bf499756dc6c0b3a238db90c",
+    "templates/varnish-vcl.erb": "2eac0a4246a070534c0b2a55f56c80e1",
+    "Modulefile": "cefd47b8ca6bfe6b40547d29e323bc52",
+    "manifests/backend.pp": "c65057e551a7c14698227c9b2930a463",
+    "tests/init.pp": "67bf92b5b6453d90daaa1da2efe307dd",
+    ".mailmap": "bbeed30f521cf299b4933034530b826f",
+    "tests/vcl_backends_probes.pp": "6c866c7533c9b022f1a1f7563be952d2",
+    "Gemfile.lock": "f682533935c9d9940d9b72cb37625bae"
+  },
+  "dependencies": [
+    {
+      "name": "puppetlabs/stdlib"
+    },
+    {
+      "name": "puppetlabs/concat"
+    },
+    {
+      "name": "puppetlabs/apt"
+    },
+    {
+      "name": "puppetlabs/firewall"
+    }
+  ],
+  "description": "Install, configure and manage VCL (Ubuntu/CentOS)",
+  "license": "Apache",
+  "name": "maxchk-varnish",
+  "project_page": "https://github.com/maxchk/puppet-varnish",
+  "source": "",
+  "summary": "Varnish module",
+  "types": [],
+  "version": "1.0.0"
+}


### PR DESCRIPTION
Fix syntax error when declaring the class varnish::install, fix wrong parameter call for varnish::firewall inside varnish::install and add default parameter for install::varnish_listen_port to fix rspec tests
