### PR TITLE
Selector names now can be different from the specified director

### DIFF
--- a/manifests/selector.pp
+++ b/manifests/selector.pp
@@ -1,5 +1,6 @@
 #selector.pp
 define varnish::selector(
+  $director = $name,
   $condition,
   $newurl = undef,
   $movedto = undef,

--- a/templates/includes/backendselection.vcl.erb
+++ b/templates/includes/backendselection.vcl.erb
@@ -2,7 +2,7 @@ if (<%= @condition -%>) {
     <%- if @movedto -%>
   error 750 "<%= @movedto -%>" + req.url;  
     <%- else -%>
-  set req.backend = <%= @title -%>;
+  set req.backend = <%= @director -%>;
       <%- if @newurl -%>
   set req.url = <%= @newurl -%>;
       <%- end -%>


### PR DESCRIPTION
Allows a selector to have a different name from its director counterpart.
