### PR TITLE
Fix disabling of repository

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -36,7 +36,7 @@ class varnish::repo (
   else {
     $osver = $osver_array[0]
   }
-  if $enable {
+  if str2bool($enable) {
     case $::osfamily {
       redhat: {
         yumrepo { 'varnish':


### PR DESCRIPTION
Per the [puppet docs](https://docs.puppetlabs.com/puppet/latest/reference/lang_datatypes.html#automatic-conversion-to-boolean) "false" is still parsed as true when treated as a boolean.

This uses the stdlib str2bool so that the repo can be disabled based on facts or other stringish things.
