### PR TITLE
ensure official repo is used when another repo provides varnish

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -43,6 +43,7 @@ class varnish::repo (
           descr          => 'varnish',
           enabled        => '1',
           gpgcheck       => '0',
+          priority       => '1',
           baseurl        => "${repo_base_url}/${repo_distro}/varnish-${repo_version}/el${osver}/${repo_arch}",
         }
       }


### PR DESCRIPTION
When another repo that provides Varnish (like EPEL) is available we need to tune priority value in order the official repo to be used
