### PR TITLE
Restart Varnish when configuration changes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -99,7 +99,7 @@ class varnish (
     mode    => '0644',
     content => template('varnish/varnish-conf.erb'),
     require => Package['varnish'],
-    notify  => Service['varnish'],
+    notify  => Exec['restart-varnish'],
   }
 
   # storage dir

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -42,4 +42,16 @@ class varnish::service (
     restart => $reload_cmd,
     require => Package['varnish'],
   }
+
+  $restart_command = $::osfamily ? {
+    'debian'    => '/etc/init.d/varnish restart',
+    'redhat'    => '/sbin/service varnish restart',
+    default     => undef,
+  }
+
+  exec {'restart-varnish':
+    command => $restart_command,
+    refreshonly => true,
+  }
+
 }


### PR DESCRIPTION
Restart Varnish when port/memory/etc configuration changes, which, unlike a change to the VCL, requires a full restart of Varnish.

Fixes #44.
