### PR TITLE
Set the default_version

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,7 +51,7 @@ class varnish (
   $varnish_vcl_conf             = '/etc/varnish/default.vcl',
   $varnish_listen_address       = '',
   $varnish_listen_port          = '6081',
-  $varnish_admin_listen_address = '127.0.0.1',
+  $varnish_admin_listen_address = 'localhost',
   $varnish_admin_listen_port    = '6082',
   $varnish_min_threads          = '5',
   $varnish_max_threads          = '500',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,6 +63,7 @@ class varnish (
   $shmlog_dir                   = '/var/lib/varnish',
   $shmlog_tempfs                = true,
   $version                      = present,
+  $default_version              = 3,
   $add_repo                     = true,
   $manage_firewall              = false,
 ) {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,6 +11,6 @@ class varnish::params {
 
   $version = $varnish::version ? {
     /4\..*/ => 4,
-    default => 3,
+    default => $varnish::default_version,
   }
 }


### PR DESCRIPTION
The default_version param is used to make a declaration like that.
This is useful when the version of varnish 4 changes

````
class { 'varnish':
        version => "present",
        default_version => '4',
    }
````