### PR TITLE
Fixed cookie removal inside Plone Resource Editor

### DIFF
--- a/templates/varnish-vcl.erb
+++ b/templates/varnish-vcl.erb
@@ -47,9 +47,11 @@ sub vcl_recv {
 
   if (
      # Static file cache
-     (req.url ~ "(?i)\.(jpg|jpeg|gif|png|tiff|tif|svg|swf|ico|css|kss|js|vsd|doc|ppt|pps|xls|pdf|mp3|mp4|m4a|ogg|mov|avi|wmv|sxw|zip|gz|bz2|tar|rar|odc|odb|odf|odg|odi|odp|ods|odt|sxc|sxd|sxi|sxw|dmg|torrent|deb|msi|iso|rpm|jar|class|flv|exe)$")||
+     ((req.url ~ "(?i)\.(jpg|jpeg|gif|png|tiff|tif|svg|swf|ico|css|kss|js|vsd|doc|ppt|pps|xls|pdf|mp3|mp4|m4a|ogg|mov|avi|wmv|sxw|zip|gz|bz2|tar|rar|odc|odb|odf|odg|odi|odp|ods|odt|sxc|sxd|sxi|sxw|dmg|torrent|deb|msi|iso|rpm|jar|class|flv|exe)$")||
      # Plone images cache
-     (req.url ~ "(?i)(image|imagem_large|image_preview|image_mini|image_thumb|image_tile|image_icon|imagem_listing)$")
+     (req.url ~ "(?i)(image|imagem_large|image_preview|image_mini|image_thumb|image_tile|image_icon|imagem_listing)$")) && 
+     # Plone resource editor
+     (req.url !~ "(?i)\@\@plone\.resourceeditor\.getfile\?path\=")
      ) {
      remove req.http.Cookie;
   }


### PR DESCRIPTION
Plone Resource Editor was not behaving correctly because the authentication cookie was being dropped from the static files. Now Varnish only drops the cookie if the URL is not from Plone Resource Editor.