### PR TITLE
Fix int comparison to be compatible with Puppet future parser

### DIFF
--- a/templates/varnish-conf.erb
+++ b/templates/varnish-conf.erb
@@ -77,7 +77,7 @@ DAEMON_OPTS="-a ${VARNISH_LISTEN_ADDRESS}:${VARNISH_LISTEN_PORT} \
              -t ${VARNISH_TTL} \
              -S ${VARNISH_SECRET_FILE} \
              -s ${VARNISH_STORAGE} \
-<% if scope.lookupvar('varnish::params::version') == '4' -%>
+<% if scope.lookupvar('varnish::params::version') == 4 -%>
              -p thread_pool_min=${VARNISH_MIN_THREADS} \
              -p thread_pool_max=${VARNISH_MAX_THREADS} \
              -p thread_pool_timeout=${VARNISH_THREAD_TIMEOUT}"


### PR DESCRIPTION
Don't unintentionally convert the int to a string before the comparison.