### PR TITLE
Update fingerprint to full id

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -51,7 +51,7 @@ class varnish::repo (
         apt::source { 'varnish':
           location   => "${repo_base_url}/${repo_distro}",
           repos      => "varnish-${repo_version}",
-          key        => 'C4DEFFEB',
+          key        => 'E98C6BBBA1CBC5C3EB2DF21C60E7C096C4DEFFEB',
           key_source => 'http://repo.varnish-cache.org/debian/GPG-key.txt',
         }
       }


### PR DESCRIPTION
Fixes warning that `apt` `1.8.0` produces when short fingerprints are used.