### PR TITLE
Add a $cond_requests boolean to varnish::vcl

### DIFF
--- a/manifests/vcl.pp
+++ b/manifests/vcl.pp
@@ -48,6 +48,7 @@ class varnish::vcl (
   $gziptypes         = [ 'text/', 'application/xml', 'application/rss', 'application/xhtml', 'application/javascript', 'application/x-javascript' ],
   $template          = undef,
   $logrealip         = false,
+  $cond_requests     = false,
 ) {
 
   include varnish

--- a/templates/varnish-vcl.erb
+++ b/templates/varnish-vcl.erb
@@ -29,8 +29,10 @@ sub vcl_recv {
   }
 <%- end -%>
 
+<%- if not @cond_requests -%>
   unset req.http.If-Modified-Since;
-  unset req.http.If-None-Match; 
+  unset req.http.If-None-Match;
+<%- end -%>
 
   # cookie sanitization
   if (req.http.Cookie) {


### PR DESCRIPTION
Add a $cond_requests boolean to varnish::vcl to control support forcontitionnal requests. 

Right now, they are always disabled/stripped, meaning we will be returning full responses to clients, even if they were only doing a freshness check that was successful. It's just wasteful.