### PR TITLE
Honor cache control

### DIFF
--- a/manifests/vcl.pp
+++ b/manifests/vcl.pp
@@ -48,6 +48,7 @@ class varnish::vcl (
   $gziptypes         = [ 'text/', 'application/xml', 'application/rss', 'application/xhtml', 'application/javascript', 'application/x-javascript' ],
   $template          = undef,
   $logrealip         = false,
+  $honor_backend_ttl = false,
 ) {
 
   include varnish

--- a/manifests/vcl.pp
+++ b/manifests/vcl.pp
@@ -48,7 +48,6 @@ class varnish::vcl (
   $gziptypes         = [ 'text/', 'application/xml', 'application/rss', 'application/xhtml', 'application/javascript', 'application/x-javascript' ],
   $template          = undef,
   $logrealip         = false,
-  $cond_requests     = false,
 ) {
 
   include varnish

--- a/manifests/vcl.pp
+++ b/manifests/vcl.pp
@@ -48,6 +48,7 @@ class varnish::vcl (
   $gziptypes         = [ 'text/', 'application/xml', 'application/rss', 'application/xhtml', 'application/javascript', 'application/x-javascript' ],
   $template          = undef,
   $logrealip         = false,
+  $cond_requests     = false,
 ) {
 
   include varnish

--- a/templates/varnish-vcl.erb
+++ b/templates/varnish-vcl.erb
@@ -159,6 +159,9 @@ sub vcl_fetch {
     remove beresp.http.Set-Cookie;
   }
 
+  <%- if @honor_backend_ttl -%>
+  if (beresp.ttl < 0) {
+  <%- end -%>
   # Default minimum cache period 
   if(!(req.http.Cookie)&&!(beresp.http.Set-Cookie)&&(req.request == "GET")) {
      set beresp.ttl = <%= @min_cache_time %>;
@@ -180,6 +183,9 @@ sub vcl_fetch {
     return (hit_for_pass);
   } 
  
+  <%- if @honor_backend_ttl -%>
+  }
+  <%- end -%>
 }
 
 sub vcl_deliver {

--- a/templates/varnish-vcl.erb
+++ b/templates/varnish-vcl.erb
@@ -29,8 +29,10 @@ sub vcl_recv {
   }
 <%- end -%>
 
+<%- if not @cond_requests -%>
   unset req.http.If-Modified-Since;
-  unset req.http.If-None-Match; 
+  unset req.http.If-None-Match;
+<%- end -%>
 
   # cookie sanitization
   if (req.http.Cookie) {

--- a/templates/varnish-vcl.erb
+++ b/templates/varnish-vcl.erb
@@ -29,10 +29,8 @@ sub vcl_recv {
   }
 <%- end -%>
 
-<%- if not @cond_requests -%>
   unset req.http.If-Modified-Since;
-  unset req.http.If-None-Match;
-<%- end -%>
+  unset req.http.If-None-Match; 
 
   # cookie sanitization
   if (req.http.Cookie) {

--- a/templates/varnish-vcl.erb
+++ b/templates/varnish-vcl.erb
@@ -162,26 +162,26 @@ sub vcl_fetch {
   <%- if @honor_backend_ttl -%>
   if (beresp.ttl < 0) {
   <%- end -%>
-  # Default minimum cache period 
-  if(!(req.http.Cookie)&&!(beresp.http.Set-Cookie)&&(req.request == "GET")) {
-     set beresp.ttl = <%= @min_cache_time %>;
-  }
+    # Default minimum cache period
+    if(!(req.http.Cookie)&&!(beresp.http.Set-Cookie)&&(req.request == "GET")) {
+       set beresp.ttl = <%= @min_cache_time %>;
+    }
 
-  if ( 
-     # Static file cache
-     (req.url ~ "(?i)\.(jpg|jpeg|gif|png|tiff|tif|svg|swf|ico|css|kss|js|vsd|doc|ppt|pps|xls|pdf|mp3|mp4|m4a|ogg|mov|avi|wmv|sxw|zip|gz|bz2|tar|rar|odc|odb|odf|odg|odi|odp|ods|odt|sxc|sxd|sxi|sxw|dmg|torrent|deb|msi|iso|rpm|jar|class|flv|exe)$")||
-     # Plone images cache
-     (req.url ~ "(?i)(image|imagem_large|image_preview|image_mini|image_thumb|image_tile|image_icon|imagem_listing)$")
-  ) {
-    set beresp.ttl = <%= @static_cache_time %>;
-    remove beresp.http.Set-Cookie;
-  }
+    if (
+       # Static file cache
+       (req.url ~ "(?i)\.(jpg|jpeg|gif|png|tiff|tif|svg|swf|ico|css|kss|js|vsd|doc|ppt|pps|xls|pdf|mp3|mp4|m4a|ogg|mov|avi|wmv|sxw|zip|gz|bz2|tar|rar|odc|odb|odf|odg|odi|odp|ods|odt|sxc|sxd|sxi|sxw|dmg|torrent|deb|msi|iso|rpm|jar|class|flv|exe)$")||
+       # Plone images cache
+       (req.url ~ "(?i)(image|imagem_large|image_preview|image_mini|image_thumb|image_tile|image_icon|imagem_listing)$")
+    ) {
+      set beresp.ttl = <%= @static_cache_time %>;
+      remove beresp.http.Set-Cookie;
+    }
 
-  #Avoid cache of objects > 100M
-  if ( beresp.http.Content-Length ~ "[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]" ) { 
-    set beresp.ttl = <%= @static_cache_time %>; 
-    return (hit_for_pass);
-  } 
+    #Avoid cache of objects > 100M
+    if ( beresp.http.Content-Length ~ "[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]" ) {
+      set beresp.ttl = <%= @static_cache_time %>;
+      return (hit_for_pass);
+    }
  
   <%- if @honor_backend_ttl -%>
   }

--- a/templates/varnish-vcl.erb
+++ b/templates/varnish-vcl.erb
@@ -163,7 +163,7 @@ sub vcl_fetch {
 
   <%- if @honor_backend_ttl -%>
   # If no explicit TTL was set by the backend
-  if (beresp.ttl < 0) {
+  if (beresp.ttl < 0s) {
   <%- end -%>
     # Default minimum cache period
     if(!(req.http.Cookie)&&!(beresp.http.Set-Cookie)&&(req.request == "GET")) {

--- a/templates/varnish-vcl.erb
+++ b/templates/varnish-vcl.erb
@@ -160,6 +160,7 @@ sub vcl_fetch {
   }
 
   <%- if @honor_backend_ttl -%>
+  # If no explicit TTL was set by the backend
   if (beresp.ttl < 0) {
   <%- end -%>
     # Default minimum cache period


### PR DESCRIPTION
Currently, the VCL caches entries by default with either $min_cache_time or $static_cache_time, irrespectively of what the backend server might specify with Cache-Control headers.

This PR adds a boolean $honor_backend_ttl, default to false, to control this behaviour.