### PR TITLE
X-Forwarded-Proto: Add optionnal support for the X-Forwarded-Proto header, including it in the VCL hash

### DIFF
--- a/manifests/vcl.pp
+++ b/manifests/vcl.pp
@@ -49,6 +49,7 @@ class varnish::vcl (
   $template          = undef,
   $logrealip         = false,
   $cond_requests     = false,
+  $x_forwarded_proto = false,
 ) {
 
   include varnish

--- a/manifests/vcl.pp
+++ b/manifests/vcl.pp
@@ -48,7 +48,6 @@ class varnish::vcl (
   $gziptypes         = [ 'text/', 'application/xml', 'application/rss', 'application/xhtml', 'application/javascript', 'application/x-javascript' ],
   $template          = undef,
   $logrealip         = false,
-  $cond_requests     = false,
 ) {
 
   include varnish

--- a/manifests/vcl.pp
+++ b/manifests/vcl.pp
@@ -48,6 +48,7 @@ class varnish::vcl (
   $gziptypes         = [ 'text/', 'application/xml', 'application/rss', 'application/xhtml', 'application/javascript', 'application/x-javascript' ],
   $template          = undef,
   $logrealip         = false,
+  $cond_requests     = false,
 ) {
 
   include varnish

--- a/templates/varnish-vcl.erb
+++ b/templates/varnish-vcl.erb
@@ -29,8 +29,10 @@ sub vcl_recv {
   }
 <%- end -%>
 
+<%- if not @cond_requests -%>
   unset req.http.If-Modified-Since;
-  unset req.http.If-None-Match; 
+  unset req.http.If-None-Match;
+<%- end -%>
 
   # cookie sanitization
   if (req.http.Cookie) {

--- a/templates/varnish-vcl.erb
+++ b/templates/varnish-vcl.erb
@@ -29,10 +29,8 @@ sub vcl_recv {
   }
 <%- end -%>
 
-<%- if not @cond_requests -%>
   unset req.http.If-Modified-Since;
-  unset req.http.If-None-Match;
-<%- end -%>
+  unset req.http.If-None-Match; 
 
   # cookie sanitization
   if (req.http.Cookie) {

--- a/templates/varnish-vcl.erb
+++ b/templates/varnish-vcl.erb
@@ -117,6 +117,11 @@ sub vcl_recv {
 }
 
 sub vcl_hash {
+  <%- if @x_forwarded_proto -%>
+  if (req.http.X-Forwarded-Proto) {
+    hash_data(req.http.X-Forwarded-Proto);
+  }
+  <%- end -%>
 }
 
 


### PR DESCRIPTION
Just set $x_forwarded_proto = true in varnish::vcl
