### PR TITLE
Add support to redirect to https when behind an SSL terminator

### DIFF
--- a/manifests/vcl.pp
+++ b/manifests/vcl.pp
@@ -48,7 +48,6 @@ class varnish::vcl (
   $gziptypes         = [ 'text/', 'application/xml', 'application/rss', 'application/xhtml', 'application/javascript', 'application/x-javascript' ],
   $template          = undef,
   $logrealip         = false,
-  $cond_requests     = false,
 ) {
 
   include varnish

--- a/manifests/vcl.pp
+++ b/manifests/vcl.pp
@@ -49,6 +49,7 @@ class varnish::vcl (
   $template          = undef,
   $logrealip         = false,
   $cond_requests     = false,
+  $https_redirect    = false,
 ) {
 
   include varnish

--- a/manifests/vcl.pp
+++ b/manifests/vcl.pp
@@ -48,6 +48,7 @@ class varnish::vcl (
   $gziptypes         = [ 'text/', 'application/xml', 'application/rss', 'application/xhtml', 'application/javascript', 'application/x-javascript' ],
   $template          = undef,
   $logrealip         = false,
+  $cond_requests     = false,
 ) {
 
   include varnish

--- a/templates/varnish-vcl.erb
+++ b/templates/varnish-vcl.erb
@@ -29,8 +29,10 @@ sub vcl_recv {
   }
 <%- end -%>
 
+<%- if not @cond_requests -%>
   unset req.http.If-Modified-Since;
-  unset req.http.If-None-Match; 
+  unset req.http.If-None-Match;
+<%- end -%>
 
   # cookie sanitization
   if (req.http.Cookie) {

--- a/templates/varnish-vcl.erb
+++ b/templates/varnish-vcl.erb
@@ -29,6 +29,23 @@ sub vcl_recv {
   }
 <%- end -%>
 
+<%- if @https_redirect -%>
+  # Redirect to https if coming over http according to X-Forwarded-Proto
+  if ( req.http.X-Forwarded-Proto && req.http.X-Forwarded-Proto !~ "(?i)https" && req.url !~ "no-ssl-rewrite" ) {
+
+    #Find what to use for hostname, either Host: or the server's ip
+    if (req.http.host) {
+        set req.http.x-redir-host = req.http.host;
+    } else {
+        set req.http.x-redir-host = server.ip;
+    }
+
+    set req.http.x-redir-url = "https://" + req.http.x-redir-host + req.url;
+
+    error 750 req.http.x-redir-url;
+  }
+<%- end -%>
+
 <%- if not @cond_requests -%>
   unset req.http.If-Modified-Since;
   unset req.http.If-None-Match;

--- a/templates/varnish-vcl.erb
+++ b/templates/varnish-vcl.erb
@@ -29,10 +29,8 @@ sub vcl_recv {
   }
 <%- end -%>
 
-<%- if not @cond_requests -%>
   unset req.http.If-Modified-Since;
-  unset req.http.If-None-Match;
-<%- end -%>
+  unset req.http.If-None-Match; 
 
   # cookie sanitization
   if (req.http.Cookie) {


### PR DESCRIPTION
Just set varnish::vcl::https_redirect to true.
  
Varnish doesn't do SSL, but if it has a SSL terminator in front of it,
usually, it recieves a X-Forwarded-Proto: HTTP header telling it if the
request was over http or https.
    
With this flag turned on, requests over http:// are redirected to https://