### PR TITLE
Added drop_stat_cookies parameter

### DIFF
--- a/manifests/vcl.pp
+++ b/manifests/vcl.pp
@@ -49,6 +49,7 @@ class varnish::vcl (
   $template          = undef,
   $logrealip         = false,
   $cond_requests     = false,
+  $drop_stat_cookies = true,
 ) {
 
   include varnish

--- a/templates/varnish-vcl.erb
+++ b/templates/varnish-vcl.erb
@@ -47,6 +47,7 @@ sub vcl_recv {
     }
   }
 
+<%- if $drop_stat_cookies -%>
   if (
      # Static file cache
      ((req.url ~ "(?i)\.(jpg|jpeg|gif|png|tiff|tif|svg|swf|ico|css|kss|js|vsd|doc|ppt|pps|xls|pdf|mp3|mp4|m4a|ogg|mov|avi|wmv|sxw|zip|gz|bz2|tar|rar|odc|odb|odf|odg|odi|odp|ods|odt|sxc|sxd|sxi|sxw|dmg|torrent|deb|msi|iso|rpm|jar|class|flv|exe)$")||
@@ -57,6 +58,7 @@ sub vcl_recv {
      ) {
      remove req.http.Cookie;
   }
+<%- end -%>
 
   <%- if @blockedips.length > 0 -%>
   # blocked list


### PR DESCRIPTION
This parameter allows the user to specify whether the static files should have all cookies dropped. The default is true, because varnish does not cache anything with a cookie. Some systems use authentication cookies even in static files, so setting this to false can be handful.