### PR TITLE
Use widely-known osfamily fact to set cfg location

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,9 +4,9 @@
 class varnish::params {
 
   # set Varnish conf location based on OS
-  $conf_file_path = $::operatingsystem ? {
-    /(?i:Centos|RedHat|OracleLinux)/  => '/etc/sysconfig/varnish',
-    default                           => '/etc/default/varnish',
+  $conf_file_path = $::osfamily ? {
+    'RedHat' => '/etc/sysconfig/varnish',
+    default  => '/etc/default/varnish',
   }
 
   $version = $varnish::version ? {


### PR DESCRIPTION
Ran into an issue on Amazon linux because this module doesn't use the standard osfamily fact to identify RedHat family OSes. It instead explicitly lists three OSes in the 'RedHat' family that should be compatible based on the RedHat family standard configuration path.