### PR TITLE
WAF Rule to block Plone/Zope Management Interface

### DIFF
--- a/templates/includes/waf.vcl.erb
+++ b/templates/includes/waf.vcl.erb
@@ -369,4 +369,21 @@
         {
           if (!(req.http.EXCE ~ ";63;")){set req.http.RULE = req.http.RULE + ";63;";}
         } 
-        #END FILE INJECTION 
+        #END FILE INJECTION
+
+
+
+        #ZOPE/PLONE MANAGEMENT INTERFACE
+        # Blocks access to ZMI
+        if (req.url ~ "(?i)/manage(_.+)?$")
+        {
+          if (!(req.http.EXCE ~ ";64;")){set req.http.RULE = req.http.RULE + ";64;";}
+        }
+
+        # Blocks acces to the Undo forms
+        if (req.url ~ "(?i)Undoform")
+        {
+          if (!(req.http.EXCE ~ ";65;")){set req.http.RULE = req.http.RULE + ";65;";}
+        }
+        #END ZOPE/PLONE MANAGEMENT INTERFACE
+


### PR DESCRIPTION
Includes two new WAF Rules to block access to the Zope Management Interface and Undo forms.