### PR TITLE
Fixed WAF rule 36

### DIFF
--- a/templates/includes/waf.vcl.erb
+++ b/templates/includes/waf.vcl.erb
@@ -209,7 +209,7 @@
           if (!(req.http.EXCE ~ ";35;")){set req.http.RULE = req.http.RULE + ";35;";}
 	}
 
-	if (req.url ~ "(?i)\.(cvs|svn|git|hg)") 
+	if (req.url ~ "(?i)\.((cvs|svn|git|hg)$)") 
         {
           if (!(req.http.EXCE ~ ";36;")){set req.http.RULE = req.http.RULE + ";36;";}
 	}


### PR DESCRIPTION
This WAF rule, which intends to prevent access to GIT, Mercurial, SVN and CVS repositories, had giving me false positives. Fixed.