### PR TITLE
Add varnish 4.1 support

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,7 +66,6 @@ class varnish (
   $shmlog_dir                   = '/var/lib/varnish',
   $shmlog_tempfs                = true,
   $version                      = present,
-  $default_version              = 3,
   $add_repo                     = true,
   $manage_firewall              = false,
 ) {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,6 +19,6 @@ class varnish::params {
 
   $version = $varnish::version ? {
     /4\..*/ => '4',
-    default => $varnish::default_version,
+    default => 3,
   }
 }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -19,7 +19,8 @@ class varnish::repo (
 
   $repo_version = $varnish::version ? {
     /^3\./  => '3.0',
-    /^4\./  => '4.0',
+    /^4\.0/ => '4.0',
+    /^4\.1/ => '4.1',
     default => '3.0',
   }
 


### PR DESCRIPTION
This pull requests adds support for Varnish 4.1 and does some little refactoring regarding the varnish::default_version parameter.