### PR TITLE
Compatibility changes for Varnish 4.1

### DIFF
--- a/templates/varnish-conf.erb
+++ b/templates/varnish-conf.erb
@@ -101,8 +101,6 @@ DAEMON_OPTS="-a <%= scope.lookupvar('varnish_listen_address') %>:<%= scope.looku
              -p vcl_dir=<%= @vcl_dir %> \
 <% end -%>
 <% if scope.lookupvar('varnish::params::version').to_i == 4 -%>
-             -u <%= scope.lookupvar('varnish_user') %> \
-             -g <%= scope.lookupvar('varnish_group') %> \
              -p thread_pool_min=<%= scope.lookupvar('varnish_min_threads') %> \
              -p thread_pool_max=<%= scope.lookupvar('varnish_max_threads') %> \
              -p thread_pool_timeout=<%= scope.lookupvar('varnish_thread_timeout') %>"

--- a/templates/varnish4-vcl.erb
+++ b/templates/varnish4-vcl.erb
@@ -98,7 +98,7 @@ sub vcl_recv {
   <%- end -%>
 
   # backend selection logic
-  include "includes/backendselection.vcl";
+  include "includes/backendselection4.vcl";
 
   <%- if @purgeips.length > 0 -%>
   # Allows purge for the IPs in purge ACL


### PR DESCRIPTION
user and group are no longer valid parameters for Varnish versions above 4.1.

The varnish4-vcl also wasn't including the correct backend selector template

close #92 