### PR TITLE
Improve version handling

### DIFF
--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -6,7 +6,7 @@ define varnish::director(
 
   validate_re($title,'^[A-Za-z0-9_]*$', "Invalid characters in director name ${title}. Only letters, numbers and underscore are allowed.")
 
-  if versioncmp($::varnish::params::version, '4') >= 0 {
+  if versioncmp($::varnish::real_version, '4') >= 0 {
     $template_director = 'varnish/includes/directors4.vcl.erb'
     $director_object = $type ? {
       'round-robin' => 'round_robin',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,10 +12,12 @@
 # $varnish_listen_port -> VARNISH_LISTEN_PORT
 #
 # Exceptions are:
+# ensure        - passed to puppet type 'package', attribute 'ensure'
 # shmlog_dir    - location for shmlog
 # shmlog_tempfs - mounts shmlog directory as tmpfs
 #                 default value: true
-# version       - passed to puppet type 'package', attribute 'ensure'
+# version       - the Varnish version to be installed (valid values are '3.0',
+#                 '4.0' and '4.1')
 # add_repo      - if set to false (defaults to true), the yum/apt repo is not added
 #
 # === Default values
@@ -44,6 +46,7 @@
 #
 
 class varnish (
+  $ensure                       = 'present',
   $start                        = 'yes',
   $reload_vcl                   = true,
   $nfiles                       = '131072',
@@ -66,7 +69,7 @@ class varnish (
   $vcl_dir                      = undef,
   $shmlog_dir                   = '/var/lib/varnish',
   $shmlog_tempfs                = true,
-  $version                      = present,
+  $version                      = '3.0',
   $add_repo                     = true,
   $manage_firewall              = false,
   $varnish_conf_template        = 'varnish/varnish-conf.erb',
@@ -75,6 +78,21 @@ class varnish (
 
   # read parameters
   include varnish::params
+
+  if ! ($version =~ /^\d+\.\d+$/) {
+    warning('$version should consist only of major and minor version numbers.')
+
+    # Extract major and minor version from the value, otherwise default to 3.0.
+    if $version =~ /^\d+\.\d+\./ {
+      $real_version = regsubst($version, '^(\d+\.\d+).*$', '\1')
+    } elsif $version == 'present' {
+      $real_version = '3.0'
+    } else {
+      fail('Invalid value for $version.')
+    }
+  } else {
+    $real_version = $version
+  }
 
   # install Varnish
   class {'varnish::install':

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,17 +4,13 @@
 #
 # === Parameters
 #
-# version - passed to puppet type 'package', attribute 'ensure'
+# ensure - passed to puppet type 'package', attribute 'ensure'
 #
 # === Examples
 #
 # install Varnish
 # class {'varnish::install':}
 #
-# make sure latest version is always installed
-# class {'varnish::install':
-#  version => latest,
-# }
 #
 
 class varnish::install (
@@ -32,8 +28,8 @@ class varnish::install (
 	  varnish_listen_port => $varnish_listen_port,
   }
 
-  # varnish package
+  # Varnish package
   package { 'varnish':
-    ensure  => $varnish::version,
+    ensure => $varnish::ensure,
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,8 +17,4 @@ class varnish::params {
     }
   }
 
-  $version = $varnish::version ? {
-    /4\..*/ => '4',
-    default => 3,
-  }
 }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -17,13 +17,6 @@ class varnish::repo (
     default     => downcase($::operatingsystem),
   }
 
-  $repo_version = $varnish::version ? {
-    /^3\./  => '3.0',
-    /^4\.0/ => '4.0',
-    /^4\.1/ => '4.1',
-    default => '3.0',
-  }
-
   $repo_arch = $::architecture
 
   $osver_array = split($::operatingsystemrelease, '[.]')
@@ -45,13 +38,13 @@ class varnish::repo (
           enabled        => '1',
           gpgcheck       => '0',
           priority       => '1',
-          baseurl        => "${repo_base_url}/${repo_distro}/varnish-${repo_version}/el${osver}/${repo_arch}",
+          baseurl        => "${repo_base_url}/${repo_distro}/varnish-${varnish::real_version}/el${osver}/${repo_arch}",
         }
       }
       debian: {
         apt::source { 'varnish':
           location   => "${repo_base_url}/${repo_distro}",
-          repos      => "varnish-${repo_version}",
+          repos      => "varnish-${varnish::real_version}",
           key        => 'E98C6BBBA1CBC5C3EB2DF21C60E7C096C4DEFFEB',
           key_source => 'http://repo.varnish-cache.org/debian/GPG-key.txt',
         }

--- a/manifests/selector.pp
+++ b/manifests/selector.pp
@@ -6,9 +6,10 @@ define varnish::selector(
   $newurl = undef,
   $movedto = undef,
 ) {
-  $template_selector = $::varnish::params::version ? {
-    '4'     => 'varnish/includes/backendselection4.vcl.erb',
-    default => 'varnish/includes/backendselection.vcl.erb',
+  if versioncmp($::varnish::real_version, '4') >= 0 {
+    $template_selector = 'varnish/includes/backendselection4.vcl.erb'
+  } else {
+    $template_selector = 'varnish/includes/backendselection.vcl.erb'
   }
 
   concat::fragment { "${title}-selector":

--- a/manifests/vcl.pp
+++ b/manifests/vcl.pp
@@ -81,16 +81,13 @@ class varnish::vcl (
     }
   }
 
-
   # select template to use
   if $template {
     $template_vcl = $template
-  }
-  else {
-    $template_vcl = $::varnish::params::version ? {
-      '4'     => 'varnish/varnish4-vcl.erb',
-      default => 'varnish/varnish-vcl.erb',
-    }
+  } elsif versioncmp($::varnish::real_version, '4') >= 0 {
+    $template_vcl = 'varnish/varnish4-vcl.erb'
+  } else {
+    $template_vcl = 'varnish/varnish-vcl.erb'
   }
 
   # vcl file

--- a/templates/varnish-conf.erb
+++ b/templates/varnish-conf.erb
@@ -12,7 +12,7 @@
 # Should we start varnishd at boot?  Set to "no" to disable.
 START=<%= scope.lookupvar('start') %>
 
-<% if scope.lookupvar('varnish::params::version').to_i == 4 -%>
+<% if scope.function_versioncmp([@real_version, '4']) >= 0 -%>
 # Should systemd reload varnish incase of a vcl change?
 <% if scope.lookupvar('reload_vcl') -%>
 RELOAD_VCL=1
@@ -21,7 +21,7 @@ RELOAD_VCL=0
 <% end -%>
 <% end -%>
 
-<% if scope.lookupvar('varnish::params::version').to_i == 4 -%>
+<% if scope.function_versioncmp([@real_version, '4']) >= 0 -%>
 # User and group for the varnishd worker processes
 VARNISH_USER=<%= scope.lookupvar('varnish_user') %>
 VARNISH_GROUP=<%= scope.lookupvar('varnish_group') %>
@@ -86,7 +86,7 @@ VARNISH_TTL=<%= scope.lookupvar('varnish_ttl') %>
 #
 # # DAEMON_OPTS is used by the init script.  If you add or remove options, make
 # # sure you update this section, too.
-# Version: <%= scope.lookupvar('varnish::params::version') %>
+# Version: <%= scope.lookupvar('varnish::real_version') %>
 DAEMON_OPTS="-a <%= scope.lookupvar('varnish_listen_address') %>:<%= scope.lookupvar('varnish_listen_port') %> \
              -f <%= scope.lookupvar('varnish_vcl_conf') %> \
              -T <%= scope.lookupvar('varnish_admin_listen_address') %>:<%= scope.lookupvar('varnish_admin_listen_port') %> \
@@ -103,7 +103,7 @@ DAEMON_OPTS="-a <%= scope.lookupvar('varnish_listen_address') %>:<%= scope.looku
 <% @additional_parameters.each do |param, value| -%>
              -p <%= param %>=<%= value %> \
 <% end -%>
-<% if scope.lookupvar('varnish::params::version').to_i == 4 -%>
+<% if scope.function_versioncmp([@real_version, '4']) >= 0 -%>
              -p thread_pool_min=<%= scope.lookupvar('varnish_min_threads') %> \
              -p thread_pool_max=<%= scope.lookupvar('varnish_max_threads') %> \
              -p thread_pool_timeout=<%= scope.lookupvar('varnish_thread_timeout') %>"


### PR DESCRIPTION
Fixes #64. Improve the handling for different versions of Varnish by splitting up the current `$varnish::version` parameter into `$varnish::ensure` (which is passed directly to `Package['varnish']`) and `$varnish::version` (which is used to specify the major-minor version number, `4.1` for example).