### PR TITLE
Add missing dependencies

### DIFF
--- a/manifests/acl.pp
+++ b/manifests/acl.pp
@@ -12,16 +12,19 @@ define varnish::acl(
         target  => "${varnish::vcl::includedir}/acls.vcl",
         content => "acl ${title} {\n",
         order   => "02-${title}-1-0",
+        notify  => Service['varnish'],
       } -> concat::fragment { "${title}-acl_tail":
         target  => "${varnish::vcl::includedir}/acls.vcl",
         content => "}\n",
         order   => "02-${title}-3-0",
+        notify  => Service['varnish'],
       }
     }
     concat::fragment { "${title}-acl_body":
       target  => "${varnish::vcl::includedir}/acls.vcl",
       content => template('varnish/includes/acls_body.vcl.erb'),
       order   => "02-${title}-2-0",
+      notify  => Service['varnish'],
     }
   }
 }
@@ -36,10 +39,12 @@ define varnish::acl_member(
       target  => "${varnish::vcl::includedir}/acls.vcl",
       content => "acl ${acl} {\n",
       order   => "02-${acl}-1-0",
+      notify  => Service['varnish'],
     } -> concat::fragment { "${acl}-acl_tail":
       target  => "${varnish::vcl::includedir}/acls.vcl",
       content => "}\n",
       order   => "02-${acl}-3-0",
+      notify  => Service['varnish'],
     }
   }
   $hosts = [$host]
@@ -47,5 +52,6 @@ define varnish::acl_member(
     target  => "${varnish::vcl::includedir}/acls.vcl",
     content => template('varnish/includes/acls_body.vcl.erb'),
     order   => "02-${acl}-2-${host}",
+    notify  => Service['varnish'],
   }
 }

--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -18,5 +18,6 @@ define varnish::backend(
     target  => "${varnish::vcl::includedir}/backends.vcl",
     content => template('varnish/includes/backends.vcl.erb'),
     order   => '02',
+    notify  => Service['varnish'],
   }
 }

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -21,5 +21,6 @@ define varnish::director(
     target  => "${varnish::vcl::includedir}/directors.vcl",
     content => template($template_director),
     order   => '02',
+    notify  => Service['varnish'],
   }
 }

--- a/manifests/probe.pp
+++ b/manifests/probe.pp
@@ -17,6 +17,7 @@ define varnish::probe(
     target  => "${varnish::vcl::includedir}/probes.vcl",
     content => template('varnish/includes/probes.vcl.erb'),
     order   => '02',
+    notify  => Service['varnish'],
   }
 
 }

--- a/manifests/selector.pp
+++ b/manifests/selector.pp
@@ -15,6 +15,7 @@ define varnish::selector(
     target  => "${varnish::vcl::includedir}/backendselection.vcl",
     content => template($template_selector),
     order   => '03',
+    notify  => Service['varnish'],
   }
 
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -54,16 +54,10 @@ class varnish::service (
     default     => undef,
   }
 
-  $status_command = $::osfamily ? {
-    'debian'    => '/etc/init.d/varnish status',
-    'redhat'    => '/sbin/service varnish status',
-    default     => undef,
-  }
-
   exec {'restart-varnish':
     command     => $restart_command,
     refreshonly => true,
-    onlyif      => $status_command,
+    require     => Service['varnish'],
   }
 
   if $::osfamily == 'RedHat' {

--- a/manifests/shmlog.pp
+++ b/manifests/shmlog.pp
@@ -49,6 +49,7 @@ class varnish::shmlog (
     options => $options,
     pass    => '0',
     dump    => '0',
+    notify  => Service['varnish'],
     require => File['shmlog-dir'],
   }
 }

--- a/manifests/vcl.pp
+++ b/manifests/vcl.pp
@@ -121,6 +121,7 @@ class varnish::vcl (
       target  => "${varnish::vcl::includedir}/waf.vcl",
       content => template('varnish/includes/waf.vcl.erb'),
       order   => '02',
+      notify  => Service['varnish'],
     }
 
     #Create resources


### PR DESCRIPTION
Currently there are a whole bunch of missing dependencies. As such, it is possible for the `varnish` service to be started withithout any backends having been defined. See the following logs, for example:

```
Notice: /Stage[main]/Varnish::Repo/Apt::Source[varnish]/Apt::Key[Add key: E98C6BBBA1CBC5C3EB2DF21C60E7C096C4DEFFEB from Apt::Source varnish]/Apt_key[Add key: E98C6BBBA1CBC5C3EB2DF21C60E7C096C4DEFFEB from Apt::Source varnish]/ensure: created
Notice: /Stage[main]/Varnish::Repo/Apt::Source[varnish]/Apt::Setting[list-varnish]/File[/etc/apt/sources.list.d/varnish.list]/ensure: created
Notice: /Stage[main]/Apt::Update/Exec[apt_update]: Triggered 'refresh' from 1 events
Notice: /Stage[main]/Varnish/File[varnish-conf]/content: content changed '{md5}c9171e93e02c1bd5249443c5e49c5966' to '{md5}ed9bb2e9e5b43705c57ef8c1db6976e4'
Notice: /Stage[main]/Varnish/File[storage-dir]/ensure: created
Notice: /Stage[main]/Varnish::Vcl/File[varnish-vcl]/content: content changed '{md5}43f33efc867d0ecd6f2ab08878a936bb' to '{md5}cc4867f7cc1c4fc93846f910ee0163b4'
Notice: /Stage[main]/Varnish::Vcl/File[/etc/varnish/includes]/ensure: created
Notice: /Stage[main]/Varnish::Shmlog/Mount[shmlog-mount]/ensure: defined 'ensure' as 'mounted'
Notice: /Stage[main]/Varnish::Shmlog/Mount[shmlog-mount]: Triggered 'refresh' from 1 events
Notice: /Stage[main]/Varnish::Service/Exec[restart-varnish]/returns:  * Checking syntax varnishd
Notice: /Stage[main]/Varnish::Service/Exec[restart-varnish]/returns:    ...fail!
Notice: /Stage[main]/Varnish::Service/Exec[restart-varnish]/returns: Message from VCC-compiler:
Notice: /Stage[main]/Varnish::Service/Exec[restart-varnish]/returns: Cannot read file 'includes/probes.vcl': No such file or directory
Notice: /Stage[main]/Varnish::Service/Exec[restart-varnish]/returns: ('input' Line 7 Pos 9)
Notice: /Stage[main]/Varnish::Service/Exec[restart-varnish]/returns: include "includes/probes.vcl";
Notice: /Stage[main]/Varnish::Service/Exec[restart-varnish]/returns: --------#####################-
Notice: /Stage[main]/Varnish::Service/Exec[restart-varnish]/returns: 
Notice: /Stage[main]/Varnish::Service/Exec[restart-varnish]/returns: Running VCC-compiler failed, exited with 2
Notice: /Stage[main]/Varnish::Service/Exec[restart-varnish]/returns: 
Notice: /Stage[main]/Varnish::Service/Exec[restart-varnish]/returns: VCL compilation failed
Notice: /Stage[main]/Varnish::Service/Exec[restart-varnish]/returns:  * Syntax check failed, not restarting
Error: /Stage[main]/Varnish::Service/Exec[restart-varnish]: Failed to call refresh: /etc/init.d/varnish restart returned 1 instead of one of [0]
Error: /Stage[main]/Varnish::Service/Exec[restart-varnish]: /etc/init.d/varnish restart returned 1 instead of one of [0]
Notice: /Stage[main]/Concat::Setup/File[/var/lib/puppet/concat]/ensure: created
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[acls]/Concat[/etc/varnish/includes/acls.vcl]/File[/var/lib/puppet/concat/_etc_varnish_includes_acls.vcl]/ensure: created
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[acls]/Concat[/etc/varnish/includes/acls.vcl]/File[/var/lib/puppet/concat/_etc_varnish_includes_acls.vcl/fragments]/ensure: created
Notice: /Stage[main]/Concat::Setup/File[/var/lib/puppet/concat/bin]/ensure: created
Notice: /Stage[main]/Concat::Setup/File[/var/lib/puppet/concat/bin/concatfragments.sh]/ensure: defined content as '{md5}7bbe7c5fce25a5ddd20415d909ba44fc'
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[acls]/Concat::Fragment[acls-header]/File[/var/lib/puppet/concat/_etc_varnish_includes_acls.vcl/fragments/01_acls-header]/ensure: defined content as '{md5}8267598c7651338a103b5c45f795e98d'
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[probes]/Concat[/etc/varnish/includes/probes.vcl]/File[/var/lib/puppet/concat/_etc_varnish_includes_probes.vcl]/ensure: created
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[probes]/Concat[/etc/varnish/includes/probes.vcl]/File[/var/lib/puppet/concat/_etc_varnish_includes_probes.vcl/fragments.concat]/ensure: created
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[probes]/Concat[/etc/varnish/includes/probes.vcl]/File[/var/lib/puppet/concat/_etc_varnish_includes_probes.vcl/fragments]/ensure: created
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[probes]/Concat::Fragment[probes-header]/File[/var/lib/puppet/concat/_etc_varnish_includes_probes.vcl/fragments/01_probes-header]/ensure: defined content as '{md5}8267598c7651338a103b5c45f795e98d'
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[acls]/Concat[/etc/varnish/includes/acls.vcl]/File[/var/lib/puppet/concat/_etc_varnish_includes_acls.vcl/fragments.concat]/ensure: created
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[acls]/Concat[/etc/varnish/includes/acls.vcl]/Exec[concat_/etc/varnish/includes/acls.vcl]/returns: executed successfully
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[acls]/Concat[/etc/varnish/includes/acls.vcl]/Exec[concat_/etc/varnish/includes/acls.vcl]: Triggered 'refresh' from 3 events
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[waf]/Concat[/etc/varnish/includes/waf.vcl]/File[/var/lib/puppet/concat/_etc_varnish_includes_waf.vcl]/ensure: created
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[waf]/Concat[/etc/varnish/includes/waf.vcl]/File[/var/lib/puppet/concat/_etc_varnish_includes_waf.vcl/fragments]/ensure: created
Notice: /Stage[main]/Varnish::Vcl/Concat::Fragment[waf]/File[/var/lib/puppet/concat/_etc_varnish_includes_waf.vcl/fragments/02_waf]/ensure: defined content as '{md5}6a18d8b9641c11ded2fcb1bccf15c49a'
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[acls]/Concat[/etc/varnish/includes/acls.vcl]/File[/etc/varnish/includes/acls.vcl]/ensure: defined content as '{md5}8267598c7651338a103b5c45f795e98d'
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[waf]/Concat[/etc/varnish/includes/waf.vcl]/File[/var/lib/puppet/concat/_etc_varnish_includes_waf.vcl/fragments.concat.out]/ensure: created
Notice: /Stage[main]/Varnish_cache4/Varnish_cache4::Backend[REDACTED]/Varnish::Probe[REDACTED_probe]/Concat::Fragment[REDACTED_probe-probe]/File[/var/lib/puppet/concat/_etc_varnish_includes_probes.vcl/fragments/02_REDACTED_probe-probe]/ensure: defined content as '{md5}e9a53839ff538688bff48be7386349bc'
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[probes]/Concat[/etc/varnish/includes/probes.vcl]/Exec[concat_/etc/varnish/includes/probes.vcl]/returns: executed successfully
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[probes]/Concat[/etc/varnish/includes/probes.vcl]/Exec[concat_/etc/varnish/includes/probes.vcl]: Triggered 'refresh' from 4 events
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[backends]/Concat[/etc/varnish/includes/backends.vcl]/File[/var/lib/puppet/concat/_etc_varnish_includes_backends.vcl]/ensure: created
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[backends]/Concat[/etc/varnish/includes/backends.vcl]/File[/var/lib/puppet/concat/_etc_varnish_includes_backends.vcl/fragments]/ensure: created
Notice: /Stage[main]/Varnish_cache4/Varnish_cache4::Backend[REDACTED]/Varnish::Backend[REDACTED_da74465d]/Concat::Fragment[REDACTED_da74465d-backend]/File[/var/lib/puppet/concat/_etc_varnish_includes_backends.vcl/fragments/02_REDACTED_da74465d-backend]/ensure: defined content as '{md5}921f40f732a50a8db7ff5f0cf6457bec'
Notice: /Stage[main]/Varnish_cache4/Varnish_cache4::Backend[REDACTED]/Varnish::Backend[REDACTED_60c6f4e7]/Concat::Fragment[REDACTED_60c6f4e7-backend]/File[/var/lib/puppet/concat/_etc_varnish_includes_backends.vcl/fragments/02_REDACTED_60c6f4e7-backend]/ensure: defined content as '{md5}e5e4d29e0c3bf9247ff1c5dc8744ae0e'
Notice: /Stage[main]/Varnish_cache4/Varnish_cache4::Backend[REDACTED]/Varnish::Backend[REDACTED_317446b6]/Concat::Fragment[REDACTED_317446b6-backend]/File[/var/lib/puppet/concat/_etc_varnish_includes_backends.vcl/fragments/02_REDACTED_317446b6-backend]/ensure: defined content as '{md5}2a61e1d3188c79ae9941b70f3b209106'
Notice: /Stage[main]/Varnish_cache4/Varnish_cache4::Backend[REDACTED]/Varnish::Backend[REDACTED_130a068e]/Concat::Fragment[REDACTED_130a068e-backend]/File[/var/lib/puppet/concat/_etc_varnish_includes_backends.vcl/fragments/02_REDACTED_130a068e-backend]/ensure: defined content as '{md5}dbf97353695934d28e37af92c4a60596'
Notice: /Stage[main]/Varnish_cache4/Varnish_cache4::Backend[REDACTED]/Varnish::Backend[REDACTED_4a4a45d7]/Concat::Fragment[REDACTED_4a4a45d7-backend]/File[/var/lib/puppet/concat/_etc_varnish_includes_backends.vcl/fragments/02_REDACTED_4a4a45d7-backend]/ensure: defined content as '{md5}ed8d9913abd6f4daab52011cf8bfbede'
Notice: /Stage[main]/Varnish_cache4/Varnish_cache4::Backend[REDACTED]/Varnish::Backend[REDACTED_08862e92]/Concat::Fragment[REDACTED_08862e92-backend]/File[/var/lib/puppet/concat/_etc_varnish_includes_backends.vcl/fragments/02_REDACTED_08862e92-backend]/ensure: defined content as '{md5}b0986fbf35430047af2429670a99bca7'
Notice: /Stage[main]/Varnish_cache4/Varnish_cache4::Backend[REDACTED]/Varnish::Backend[REDACTED_528f9fcf]/Concat::Fragment[REDACTED_528f9fcf-backend]/File[/var/lib/puppet/concat/_etc_varnish_includes_backends.vcl/fragments/02_REDACTED_528f9fcf-backend]/ensure: defined content as '{md5}96a12417f8d3f54e51b2bb3e6ecc8090'
Notice: /Stage[main]/Varnish_cache4/Varnish_cache4::Backend[REDACTED]/Varnish::Backend[REDACTED_5f57f1c5]/Concat::Fragment[REDACTED_5f57f1c5-backend]/File[/var/lib/puppet/concat/_etc_varnish_includes_backends.vcl/fragments/02_REDACTED_5f57f1c5-backend]/ensure: defined content as '{md5}46925c5d5ce991948d698c73aec8aa36'
Notice: /Stage[main]/Varnish_cache4/Varnish_cache4::Backend[REDACTED]/Varnish::Backend[REDACTED_35862eaf]/Concat::Fragment[REDACTED_35862eaf-backend]/File[/var/lib/puppet/concat/_etc_varnish_includes_backends.vcl/fragments/02_REDACTED_35862eaf-backend]/ensure: defined content as '{md5}21a8f61fb58d763f92cea63da65c6125'
Notice: /Stage[main]/Varnish_cache4/Varnish_cache4::Backend[REDACTED]/Varnish::Backend[REDACTED_307446b7]/Concat::Fragment[REDACTED_307446b7-backend]/File[/var/lib/puppet/concat/_etc_varnish_includes_backends.vcl/fragments/02_REDACTED_307446b7-backend]/ensure: defined content as '{md5}87be79b283d462a8ba156c32228cb179'
Notice: /Stage[main]/Varnish_cache4/Varnish_cache4::Backend[REDACTED]/Varnish::Backend[REDACTED_37862ead]/Concat::Fragment[REDACTED_37862ead-backend]/File[/var/lib/puppet/concat/_etc_varnish_includes_backends.vcl/fragments/02_REDACTED_37862ead-backend]/ensure: defined content as '{md5}9ed05ea03c3bdad4e5d8545438fb75db'
Notice: /Stage[main]/Varnish_cache4/Varnish_cache4::Backend[REDACTED]/Varnish::Backend[REDACTED_be0a0623]/Concat::Fragment[REDACTED_be0a0623-backend]/File[/var/lib/puppet/concat/_etc_varnish_includes_backends.vcl/fragments/02_REDACTED_be0a0623-backend]/ensure: defined content as '{md5}b62379bc06f3d2200f3f767d0ae55c04'
Notice: /Stage[main]/Varnish_cache4/Varnish_cache4::Backend[REDACTED]/Varnish::Backend[REDACTED_a5a4053f]/Concat::Fragment[REDACTED_a5a4053f-backend]/File[/var/lib/puppet/concat/_etc_varnish_includes_backends.vcl/fragments/02_REDACTED_a5a4053f-backend]/ensure: defined content as '{md5}a563b73d70b78787c988fea69e42f5f1'
Notice: /Stage[main]/Varnish_cache4/Varnish_cache4::Backend[REDACTED]/Varnish::Backend[REDACTED_9149460c]/Concat::Fragment[REDACTED_9149460c-backend]/File[/var/lib/puppet/concat/_etc_varnish_includes_backends.vcl/fragments/02_REDACTED_9149460c-backend]/ensure: defined content as '{md5}b529010cbde7c92907b8c9ce1f20fb58'
Notice: /Stage[main]/Varnish_cache4/Varnish_cache4::Backend[REDACTED]/Varnish::Backend[REDACTED_bf0a0622]/Concat::Fragment[REDACTED_bf0a0622-backend]/File[/var/lib/puppet/concat/_etc_varnish_includes_backends.vcl/fragments/02_REDACTED_bf0a0622-backend]/ensure: defined content as '{md5}b769493a976341782ce40c747273e545'
Notice: /Stage[main]/Varnish_cache4/Varnish_cache4::Backend[REDACTED]/Varnish::Backend[REDACTED_5c57f1c6]/Concat::Fragment[REDACTED_5c57f1c6-backend]/File[/var/lib/puppet/concat/_etc_varnish_includes_backends.vcl/fragments/02_REDACTED_5c57f1c6-backend]/ensure: defined content as '{md5}913a1a5f5282f936de5a2dbe21e0b9d5'
Notice: /Stage[main]/Varnish_cache4/Varnish_cache4::Backend[REDACTED]/Varnish::Backend[REDACTED_29d1d7ae]/Concat::Fragment[REDACTED_29d1d7ae-backend]/File[/var/lib/puppet/concat/_etc_varnish_includes_backends.vcl/fragments/02_REDACTED_29d1d7ae-backend]/ensure: defined content as '{md5}6cc90eb64ee72edd4bfb14d063593559'
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[backends]/Concat::Fragment[backends-header]/File[/var/lib/puppet/concat/_etc_varnish_includes_backends.vcl/fragments/01_backends-header]/ensure: defined content as '{md5}8267598c7651338a103b5c45f795e98d'
Notice: /Stage[main]/Varnish_cache4/Varnish_cache4::Backend[REDACTED]/Varnish::Backend[REDACTED_414a45dc]/Concat::Fragment[REDACTED_414a45dc-backend]/File[/var/lib/puppet/concat/_etc_varnish_includes_backends.vcl/fragments/02_REDACTED_414a45dc-backend]/ensure: defined content as '{md5}05499d120e741a9e82c30094937a4ed9'
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[backends]/Concat[/etc/varnish/includes/backends.vcl]/File[/var/lib/puppet/concat/_etc_varnish_includes_backends.vcl/fragments.concat]/ensure: created
Notice: /Stage[main]/Varnish_cache4/Varnish_cache4::Backend[REDACTED]/Varnish::Backend[REDACTED_518f9fcc]/Concat::Fragment[REDACTED_518f9fcc-backend]/File[/var/lib/puppet/concat/_etc_varnish_includes_backends.vcl/fragments/02_REDACTED_518f9fcc-backend]/ensure: defined content as '{md5}f074dbce03c865619f2ec0163adb3cc8'
Notice: /Stage[main]/Varnish_cache4/Varnish_cache4::Backend[REDACTED]/Varnish::Backend[REDACTED_1c0a0681]/Concat::Fragment[REDACTED_1c0a0681-backend]/File[/var/lib/puppet/concat/_etc_varnish_includes_backends.vcl/fragments/02_REDACTED_1c0a0681-backend]/ensure: defined content as '{md5}ff9349fbf9685cdd4942c2f6024e93f2'
Notice: /Stage[main]/Varnish_cache4/Varnish_cache4::Backend[REDACTED]/Varnish::Backend[REDACTED_36862eac]/Concat::Fragment[REDACTED_36862eac-backend]/File[/var/lib/puppet/concat/_etc_varnish_includes_backends.vcl/fragments/02_REDACTED_36862eac-backend]/ensure: defined content as '{md5}f1c46a09eb096d07a695700730f9d08f'
Notice: /Stage[main]/Varnish_cache4/Varnish_cache4::Backend[REDACTED]/Varnish::Backend[REDACTED_7fc6f4f8]/Concat::Fragment[REDACTED_7fc6f4f8-backend]/File[/var/lib/puppet/concat/_etc_varnish_includes_backends.vcl/fragments/02_REDACTED_7fc6f4f8-backend]/ensure: defined content as '{md5}38e28b66891b0997fed1f79554788017'
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[backends]/Concat[/etc/varnish/includes/backends.vcl]/File[/var/lib/puppet/concat/_etc_varnish_includes_backends.vcl/fragments.concat.out]/ensure: created
Notice: /Stage[main]/Varnish_cache4/Varnish_cache4::Backend[REDACTED]/Varnish::Backend[REDACTED_7ec6f4f9]/Concat::Fragment[REDACTED_7ec6f4f9-backend]/File[/var/lib/puppet/concat/_etc_varnish_includes_backends.vcl/fragments/02_REDACTED_7ec6f4f9-backend]/ensure: defined content as '{md5}e71bb241e128418c7e68a143e2df694e'
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[waf]/Concat[/etc/varnish/includes/waf.vcl]/File[/var/lib/puppet/concat/_etc_varnish_includes_waf.vcl/fragments.concat]/ensure: created
Notice: /Stage[main]/Varnish_cache4/Varnish_cache4::Backend[REDACTED]/Varnish::Backend[REDACTED_a3a40539]/Concat::Fragment[REDACTED_a3a40539-backend]/File[/var/lib/puppet/concat/_etc_varnish_includes_backends.vcl/fragments/02_REDACTED_a3a40539-backend]/ensure: defined content as '{md5}44491a4de02982021d2a90166cf07694'
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[waf]/Concat::Fragment[waf-header]/File[/var/lib/puppet/concat/_etc_varnish_includes_waf.vcl/fragments/01_waf-header]/ensure: defined content as '{md5}8267598c7651338a103b5c45f795e98d'
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[waf]/Concat[/etc/varnish/includes/waf.vcl]/Exec[concat_/etc/varnish/includes/waf.vcl]/returns: executed successfully
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[waf]/Concat[/etc/varnish/includes/waf.vcl]/Exec[concat_/etc/varnish/includes/waf.vcl]: Triggered 'refresh' from 4 events
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[waf]/Concat[/etc/varnish/includes/waf.vcl]/File[/etc/varnish/includes/waf.vcl]/ensure: defined content as '{md5}783740c908b519c947fe21117aef5c21'
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[backendselection]/Concat[/etc/varnish/includes/backendselection.vcl]/File[/var/lib/puppet/concat/_etc_varnish_includes_backendselection.vcl]/ensure: created
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[backendselection]/Concat[/etc/varnish/includes/backendselection.vcl]/File[/var/lib/puppet/concat/_etc_varnish_includes_backendselection.vcl/fragments.concat]/ensure: created
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[backendselection]/Concat[/etc/varnish/includes/backendselection.vcl]/File[/var/lib/puppet/concat/_etc_varnish_includes_backendselection.vcl/fragments]/ensure: created
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[backendselection]/Concat::Fragment[backendselection-header]/File[/var/lib/puppet/concat/_etc_varnish_includes_backendselection.vcl/fragments/01_backendselection-header]/ensure: defined content as '{md5}8267598c7651338a103b5c45f795e98d'
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[backendselection]/Concat[/etc/varnish/includes/backendselection.vcl]/Exec[concat_/etc/varnish/includes/backendselection.vcl]/returns: executed successfully
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[backendselection]/Concat[/etc/varnish/includes/backendselection.vcl]/Exec[concat_/etc/varnish/includes/backendselection.vcl]: Triggered 'refresh' from 3 events
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[backendselection]/Concat[/etc/varnish/includes/backendselection.vcl]/File[/etc/varnish/includes/backendselection.vcl]/ensure: defined content as '{md5}8267598c7651338a103b5c45f795e98d'
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[probes]/Concat[/etc/varnish/includes/probes.vcl]/File[/etc/varnish/includes/probes.vcl]/ensure: defined content as '{md5}8c30cf345b114abd86d531abca27440f'
Notice: /Stage[main]/Varnish_cache4/Varnish_cache4::Backend[REDACTED]/Varnish::Backend[REDACTED_a2a40538]/Concat::Fragment[REDACTED_a2a40538-backend]/File[/var/lib/puppet/concat/_etc_varnish_includes_backends.vcl/fragments/02_REDACTED_a2a40538-backend]/ensure: defined content as '{md5}e7521a1a0d70177ad9766adfdc72c09d'
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[directors]/Concat[/etc/varnish/includes/directors.vcl]/File[/var/lib/puppet/concat/_etc_varnish_includes_directors.vcl]/ensure: created
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[directors]/Concat[/etc/varnish/includes/directors.vcl]/File[/var/lib/puppet/concat/_etc_varnish_includes_directors.vcl/fragments]/ensure: created
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[directors]/Concat[/etc/varnish/includes/directors.vcl]/File[/var/lib/puppet/concat/_etc_varnish_includes_directors.vcl/fragments.concat]/ensure: created
Notice: /Stage[main]/Varnish_cache4/Varnish_cache4::Backend[REDACTED]/Varnish::Director[REDACTED_director]/Concat::Fragment[REDACTED_director-director]/File[/var/lib/puppet/concat/_etc_varnish_includes_directors.vcl/fragments/02_REDACTED_director-director]/ensure: defined content as '{md5}ad2cc0a690896b9f59afd87550d6968b'
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[directors]/Concat::Fragment[directors-header]/File[/var/lib/puppet/concat/_etc_varnish_includes_directors.vcl/fragments/01_directors-header]/ensure: defined content as '{md5}8267598c7651338a103b5c45f795e98d'
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[directors]/Concat[/etc/varnish/includes/directors.vcl]/Exec[concat_/etc/varnish/includes/directors.vcl]/returns: executed successfully
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[directors]/Concat[/etc/varnish/includes/directors.vcl]/Exec[concat_/etc/varnish/includes/directors.vcl]: Triggered 'refresh' from 4 events
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[directors]/Concat[/etc/varnish/includes/directors.vcl]/File[/etc/varnish/includes/directors.vcl]/ensure: defined content as '{md5}a4e9d4ea2f4c5a062ac5f5469bb11076'
Notice: /Stage[main]/Varnish_cache4/Varnish_cache4::Backend[REDACTED]/Varnish::Backend[REDACTED_a4c7f523]/Concat::Fragment[REDACTED_a4c7f523-backend]/File[/var/lib/puppet/concat/_etc_varnish_includes_backends.vcl/fragments/02_REDACTED_a4c7f523-backend]/ensure: defined content as '{md5}8f7b521d4fc0b4e3878447dbfb8c376b'
Notice: /Stage[main]/Varnish_cache4/Varnish_cache4::Backend[REDACTED]/Varnish::Backend[REDACTED_d974465e]/Concat::Fragment[REDACTED_d974465e-backend]/File[/var/lib/puppet/concat/_etc_varnish_includes_backends.vcl/fragments/02_REDACTED_d974465e-backend]/ensure: defined content as '{md5}4151131b4c54b611045e9441f7be97d1'
Notice: /Stage[main]/Varnish_cache4/Varnish_cache4::Backend[REDACTED]/Varnish::Backend[REDACTED_5e57f1c4]/Concat::Fragment[REDACTED_5e57f1c4-backend]/File[/var/lib/puppet/concat/_etc_varnish_includes_backends.vcl/fragments/02_REDACTED_5e57f1c4-backend]/ensure: defined content as '{md5}9cab5f8acbc26da19ae578143d4bcc2f'
Notice: /Stage[main]/Varnish_cache4/Varnish_cache4::Backend[REDACTED]/Varnish::Backend[REDACTED_404a45dd]/Concat::Fragment[REDACTED_404a45dd-backend]/File[/var/lib/puppet/concat/_etc_varnish_includes_backends.vcl/fragments/02_REDACTED_404a45dd-backend]/ensure: defined content as '{md5}d600fbf10dbd4fe318183e090aa40ce6'
Notice: /Stage[main]/Varnish_cache4/Varnish_cache4::Backend[REDACTED]/Varnish::Backend[REDACTED_327446b5]/Concat::Fragment[REDACTED_327446b5-backend]/File[/var/lib/puppet/concat/_etc_varnish_includes_backends.vcl/fragments/02_REDACTED_327446b5-backend]/ensure: defined content as '{md5}78a025ddfa32904ad18b3596a54f0ef3'
Notice: /Stage[main]/Varnish_cache4/Varnish_cache4::Backend[REDACTED]/Varnish::Backend[REDACTED_a4a4053e]/Concat::Fragment[REDACTED_a4a4053e-backend]/File[/var/lib/puppet/concat/_etc_varnish_includes_backends.vcl/fragments/02_REDACTED_a4a4053e-backend]/ensure: defined content as '{md5}1e0c70d240697860dbbb1a6d9aaa2ce9'
Notice: /Stage[main]/Varnish_cache4/Varnish_cache4::Backend[REDACTED]/Varnish::Backend[REDACTED_120a068f]/Concat::Fragment[REDACTED_120a068f-backend]/File[/var/lib/puppet/concat/_etc_varnish_includes_backends.vcl/fragments/02_REDACTED_120a068f-backend]/ensure: defined content as '{md5}f3e2993d8b6696e9e6b071dc1d280dd8'
Notice: /Stage[main]/Varnish_cache4/Varnish_cache4::Backend[REDACTED]/Varnish::Backend[REDACTED_0f744688]/Concat::Fragment[REDACTED_0f744688-backend]/File[/var/lib/puppet/concat/_etc_varnish_includes_backends.vcl/fragments/02_REDACTED_0f744688-backend]/ensure: defined content as '{md5}0902155ebb5f7412b3f2193a386a66d1'
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[backends]/Concat[/etc/varnish/includes/backends.vcl]/Exec[concat_/etc/varnish/includes/backends.vcl]/returns: executed successfully
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[backends]/Concat[/etc/varnish/includes/backends.vcl]/Exec[concat_/etc/varnish/includes/backends.vcl]: Triggered 'refresh' from 36 events
Notice: /Stage[main]/Varnish::Vcl/Varnish::Vcl::Includefile[backends]/Concat[/etc/varnish/includes/backends.vcl]/File[/etc/varnish/includes/backends.vcl]/ensure: defined content as '{md5}c302c651d377449fabdb7b7649f55ce0'
Notice: /Stage[main]/Varnish::Service/Service[varnish]: Triggered 'refresh' from 7 events
Notice: Finished catalog run in 27.91 seconds
```

This pull request adds missing dependencies between `Varnish::Acl`, `Varnish::Backend`, `Varnish::Director`, `Varnish::Probe`, `Varnish::Selector` and `Service['varnish']`.