### PR TITLE
Allow whitespace in `varnishncsa` logging format

### DIFF
--- a/manifests/ncsa.pp
+++ b/manifests/ncsa.pp
@@ -1,6 +1,7 @@
 class varnish::ncsa (
   $enable = true,
   $varnishncsa_daemon_opts = undef,
+  $log_format = undef,
 ) {
 
   file { '/etc/default/varnishncsa':

--- a/templates/varnishncsa-default.erb
+++ b/templates/varnishncsa-default.erb
@@ -14,3 +14,8 @@ VARNISHNCSA_ENABLED=1
 <% if @varnishncsa_daemon_opts -%>
 DAEMON_OPTS="${DAEMON_OPTS} <%= @varnishncsa_daemon_opts %>"
 <% end -%>
+
+<% if @log_format -%>
+LOG_FORMAT="<%= @log_format %>"
+DAEMON_OPTS="${DAEMON_OPTS} -F '${LOG_FORMAT}'"
+<% end -%>


### PR DESCRIPTION
Add a `$log_format` parameter to the `varnish::ncsa` class to workaround issues with startup scripts and shell escaping. See https://www.varnish-cache.org/lists/pipermail/varnish-misc/2012-May/022078.html.