### PR TITLE
Add ability to set custom log format for `varnishncsa`

### DIFF
--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -6,7 +6,7 @@ define varnish::director(
 
   validate_re($title,'^[A-Za-z0-9_]*$', "Invalid characters in director name ${title}. Only letters, numbers and underscore are allowed.")
 
-  if versioncmp($::varnish::params::version, '4') >= 0 {
+  if versioncmp($::varnish::real_version, '4') >= 0 {
     $template_director = 'varnish/includes/directors4.vcl.erb'
     $director_object = $type ? {
       'round-robin' => 'round_robin',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,10 +12,12 @@
 # $varnish_listen_port -> VARNISH_LISTEN_PORT
 #
 # Exceptions are:
+# ensure        - passed to puppet type 'package', attribute 'ensure'
 # shmlog_dir    - location for shmlog
 # shmlog_tempfs - mounts shmlog directory as tmpfs
 #                 default value: true
-# version       - passed to puppet type 'package', attribute 'ensure'
+# version       - the Varnish version to be installed (valid values are '3.0',
+#                 '4.0' and '4.1')
 # add_repo      - if set to false (defaults to true), the yum/apt repo is not added
 #
 # === Default values
@@ -44,6 +46,7 @@
 #
 
 class varnish (
+  $ensure                       = 'present',
   $start                        = 'yes',
   $reload_vcl                   = true,
   $nfiles                       = '131072',
@@ -66,7 +69,7 @@ class varnish (
   $vcl_dir                      = undef,
   $shmlog_dir                   = '/var/lib/varnish',
   $shmlog_tempfs                = true,
-  $version                      = present,
+  $version                      = '3.0',
   $add_repo                     = true,
   $manage_firewall              = false,
   $varnish_conf_template        = 'varnish/varnish-conf.erb',
@@ -75,6 +78,21 @@ class varnish (
 
   # read parameters
   include varnish::params
+
+  if ! ($version =~ /^\d+\.\d+$/) {
+    warning('$version should consist only of major and minor version numbers.')
+
+    # Extract major and minor version from the value, otherwise default to 3.0.
+    if $version =~ /^\d+\.\d+\./ {
+      $real_version = regsubst($version, '^(\d+\.\d+).*$', '\1')
+    } elsif $version == 'present' {
+      $real_version = '3.0'
+    } else {
+      fail('Invalid value for $version.')
+    }
+  } else {
+    $real_version = $version
+  }
 
   # install Varnish
   class {'varnish::install':

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,17 +4,13 @@
 #
 # === Parameters
 #
-# version - passed to puppet type 'package', attribute 'ensure'
+# ensure - passed to puppet type 'package', attribute 'ensure'
 #
 # === Examples
 #
 # install Varnish
 # class {'varnish::install':}
 #
-# make sure latest version is always installed
-# class {'varnish::install':
-#  version => latest,
-# }
 #
 
 class varnish::install (
@@ -32,8 +28,8 @@ class varnish::install (
 	  varnish_listen_port => $varnish_listen_port,
   }
 
-  # varnish package
+  # Varnish package
   package { 'varnish':
-    ensure  => $varnish::version,
+    ensure => $varnish::ensure,
   }
 }

--- a/manifests/ncsa.pp
+++ b/manifests/ncsa.pp
@@ -1,10 +1,36 @@
 class varnish::ncsa (
   $enable = true,
   $varnishncsa_daemon_opts = undef,
+  $log_format = undef,
 ) {
 
+  $log_format_file = '/etc/varnish/ncsa-format'
+
+  # TODO: We should raise an error if a custom log format is specified when
+  # `versioncmp($::varnish::real_version, '4') < 0`. This is not trivial to do,
+  # however, because it is currently possible to use `Class['varnish::ncsa']`
+  # without using `Class['varnish']`. One possible solution here is to add a
+  # `$::varnish_version` fact.
+  if $log_format {
+    $format_ensure  = 'file'
+    $format_content = $log_format
+  } else {
+    $format_ensure  = 'absent'
+    $format_content = undef
+  }
+
+  file { $log_format_file:
+    ensure  => $format_ensure,
+    mode    => '0644',
+    owner   => 'root',
+    group   => 'root',
+    content => $format_content,
+    notify  => Service['varnishncsa'],
+    require => Package['varnish'],
+  }
+
   file { '/etc/default/varnishncsa':
-    ensure  => 'present',
+    ensure  => 'file',
     mode    => '0644',
     owner   => 'root',
     group   => 'root',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,8 +17,4 @@ class varnish::params {
     }
   }
 
-  $version = $varnish::version ? {
-    /4\..*/ => '4',
-    default => 3,
-  }
 }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -17,13 +17,6 @@ class varnish::repo (
     default     => downcase($::operatingsystem),
   }
 
-  $repo_version = $varnish::version ? {
-    /^3\./  => '3.0',
-    /^4\.0/ => '4.0',
-    /^4\.1/ => '4.1',
-    default => '3.0',
-  }
-
   $repo_arch = $::architecture
 
   $osver_array = split($::operatingsystemrelease, '[.]')
@@ -45,13 +38,13 @@ class varnish::repo (
           enabled        => '1',
           gpgcheck       => '0',
           priority       => '1',
-          baseurl        => "${repo_base_url}/${repo_distro}/varnish-${repo_version}/el${osver}/${repo_arch}",
+          baseurl        => "${repo_base_url}/${repo_distro}/varnish-${varnish::real_version}/el${osver}/${repo_arch}",
         }
       }
       debian: {
         apt::source { 'varnish':
           location   => "${repo_base_url}/${repo_distro}",
-          repos      => "varnish-${repo_version}",
+          repos      => "varnish-${varnish::real_version}",
           key        => 'E98C6BBBA1CBC5C3EB2DF21C60E7C096C4DEFFEB',
           key_source => 'http://repo.varnish-cache.org/debian/GPG-key.txt',
         }

--- a/manifests/selector.pp
+++ b/manifests/selector.pp
@@ -6,9 +6,10 @@ define varnish::selector(
   $newurl = undef,
   $movedto = undef,
 ) {
-  $template_selector = $::varnish::params::version ? {
-    '4'     => 'varnish/includes/backendselection4.vcl.erb',
-    default => 'varnish/includes/backendselection.vcl.erb',
+  if versioncmp($::varnish::real_version, '4') >= 0 {
+    $template_selector = 'varnish/includes/backendselection4.vcl.erb'
+  } else {
+    $template_selector = 'varnish/includes/backendselection.vcl.erb'
   }
 
   concat::fragment { "${title}-selector":

--- a/manifests/vcl.pp
+++ b/manifests/vcl.pp
@@ -81,16 +81,13 @@ class varnish::vcl (
     }
   }
 
-
   # select template to use
   if $template {
     $template_vcl = $template
-  }
-  else {
-    $template_vcl = $::varnish::params::version ? {
-      '4'     => 'varnish/varnish4-vcl.erb',
-      default => 'varnish/varnish-vcl.erb',
-    }
+  } elsif versioncmp($::varnish::real_version, '4') >= 0 {
+    $template_vcl = 'varnish/varnish4-vcl.erb'
+  } else {
+    $template_vcl = 'varnish/varnish-vcl.erb'
   }
 
   # vcl file

--- a/spec/classes/varnish_ncsa_spec.rb
+++ b/spec/classes/varnish_ncsa_spec.rb
@@ -7,8 +7,9 @@ describe 'varnish::ncsa', :type => :class do
 
   context 'default values' do
     it { should compile }
+
     it { should contain_file('/etc/default/varnishncsa').with(
-      'ensure'  => 'present',
+      'ensure'  => 'file',
       'owner'   => 'root',
       'group'   => 'root',
       'mode'    => '0644',
@@ -17,6 +18,7 @@ describe 'varnish::ncsa', :type => :class do
     }
     it { should contain_file('/etc/default/varnishncsa').with_content(/VARNISHNCSA_ENABLED=1/) }
     it { should contain_file('/etc/default/varnishncsa').without_content(/DAEMON_OPTS/) }
+
     it { should contain_service('varnishncsa').with(
       'ensure'    => 'running',
       'require'   => 'Service[varnish]',
@@ -24,11 +26,11 @@ describe 'varnish::ncsa', :type => :class do
       )
     }
   end
-  
+
   context 'with enable false' do
     let(:params) { { :enable => false } }
     it { should contain_file('/etc/default/varnishncsa').with_content(/# VARNISHNCSA_ENABLED=1/) }
-    it { should contain_service('varnishncsa').with('ensure' => 'stopped') }      
+    it { should contain_service('varnishncsa').with('ensure' => 'stopped') }
   end
-  
+
 end

--- a/templates/varnish-conf.erb
+++ b/templates/varnish-conf.erb
@@ -12,7 +12,7 @@
 # Should we start varnishd at boot?  Set to "no" to disable.
 START=<%= scope.lookupvar('start') %>
 
-<% if scope.lookupvar('varnish::params::version').to_i == 4 -%>
+<% if scope.function_versioncmp([@real_version, '4']) >= 0 -%>
 # Should systemd reload varnish incase of a vcl change?
 <% if scope.lookupvar('reload_vcl') -%>
 RELOAD_VCL=1
@@ -21,7 +21,7 @@ RELOAD_VCL=0
 <% end -%>
 <% end -%>
 
-<% if scope.lookupvar('varnish::params::version').to_i == 4 -%>
+<% if scope.function_versioncmp([@real_version, '4']) >= 0 -%>
 # User and group for the varnishd worker processes
 VARNISH_USER=<%= scope.lookupvar('varnish_user') %>
 VARNISH_GROUP=<%= scope.lookupvar('varnish_group') %>
@@ -86,7 +86,7 @@ VARNISH_TTL=<%= scope.lookupvar('varnish_ttl') %>
 #
 # # DAEMON_OPTS is used by the init script.  If you add or remove options, make
 # # sure you update this section, too.
-# Version: <%= scope.lookupvar('varnish::params::version') %>
+# Version: <%= scope.lookupvar('varnish::real_version') %>
 DAEMON_OPTS="-a <%= scope.lookupvar('varnish_listen_address') %>:<%= scope.lookupvar('varnish_listen_port') %> \
              -f <%= scope.lookupvar('varnish_vcl_conf') %> \
              -T <%= scope.lookupvar('varnish_admin_listen_address') %>:<%= scope.lookupvar('varnish_admin_listen_port') %> \
@@ -103,7 +103,7 @@ DAEMON_OPTS="-a <%= scope.lookupvar('varnish_listen_address') %>:<%= scope.looku
 <% @additional_parameters.each do |param, value| -%>
              -p <%= param %>=<%= value %> \
 <% end -%>
-<% if scope.lookupvar('varnish::params::version').to_i == 4 -%>
+<% if scope.function_versioncmp([@real_version, '4']) >= 0 -%>
              -p thread_pool_min=<%= scope.lookupvar('varnish_min_threads') %> \
              -p thread_pool_max=<%= scope.lookupvar('varnish_max_threads') %> \
              -p thread_pool_timeout=<%= scope.lookupvar('varnish_thread_timeout') %>"

--- a/templates/varnishncsa-default.erb
+++ b/templates/varnishncsa-default.erb
@@ -14,3 +14,8 @@ VARNISHNCSA_ENABLED=1
 <% if @varnishncsa_daemon_opts -%>
 DAEMON_OPTS="${DAEMON_OPTS} <%= @varnishncsa_daemon_opts %>"
 <% end -%>
+
+<% if @log_format -%>
+# Custom output format.
+DAEMON_OPTS="${DAEMON_OPTS} -f <%= @log_format_file %>"
+<% end -%>


### PR DESCRIPTION
Improve `/etc/default/varnishncsa` to improve support for custom log formats containing whitespace by moving the logging format to a file and reading it into `varnishncsa` with the `-f` flag.

See also the following resources:

  - https://www.varnish-cache.org/lists/pipermail/varnish-misc/2012-May/022081.html
  - http://www.stroppykitten.com/drupal/node/21
  - https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=657449
  - https://bugs.debian.org/cgi-bin/bugreport.cgi?att=1;filename=varnishncsa-custom-logformat.patch;msg=5;bug=657449
  - http://www.gossamer-threads.com/lists/varnish/misc/21237
  - http://giantdorks.org/alain/workaround-for-broken-varnishncsa-logging-due-to-shell-mishandling-of-spaces-in-log_format-variables/