### PR TITLE
Fix Varnish 4 VCL

### DIFF
--- a/templates/varnish4-vcl.erb
+++ b/templates/varnish4-vcl.erb
@@ -98,7 +98,7 @@ sub vcl_recv {
   <%- end -%>
 
   # backend selection logic
-  include "includes/backendselection4.vcl";
+  include "includes/backendselection.vcl";
 
   <%- if @purgeips.length > 0 -%>
   # Allows purge for the IPs in purge ACL


### PR DESCRIPTION
In `varnish4-vcl.erb` there is a reference to `includes/backendselection4.vcl`, although this file name is incorrect. The relevant code from `varnish::selector`:

```pp
if versioncmp($::varnish::real_version, '4') >= 0 {
  $template_selector = 'varnish/includes/backendselection4.vcl.erb'
} else {
  $template_selector = 'varnish/includes/backendselection.vcl.erb'
}

concat::fragment { "${title}-selector":
  target  => "${varnish::vcl::includedir}/backendselection.vcl",
  content => template($template_selector),
  order   => '03',
  notify  => Service['varnish'],
}
```