### PR TITLE
Conf file path

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -120,7 +120,7 @@ class varnish (
   # varnish config file
   file { 'varnish-conf':
     ensure  => present,
-    path    => $varnish::params::conf_file_path,
+    path    => $conf_file_path,
     owner   => 'root',
     group   => 'root',
     mode    => '0644',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -76,6 +76,7 @@ class varnish (
   $varnish_identity             = undef,
   $additional_parameters        = {},
   $additional_storages          = {},
+  $conf_file_path               = $::varnish::params::conf_file_path,
 ) {
 
   # read parameters


### PR DESCRIPTION
In one of the previous pull requests that were merged, support for systemd was added on ubuntu.
This can be re-used for other debian distros, however the parameter conf_file_path cant be overridden.

I made the parameter in the init.pp so that it can be overridden there, to increase systemd compatibility with other distros.