### PR TITLE
Fix `$conf_file_path`

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -76,8 +76,8 @@ class varnish (
   $varnish_identity             = undef,
   $additional_parameters        = {},
   $additional_storages          = {},
-  $conf_file_path               = $::varnish::params::conf_file_path,
-) {
+  $conf_file_path               = $varnish::params::conf_file_path,
+) inherits varnish::params {
 
   # read parameters
   include varnish::params
@@ -119,7 +119,7 @@ class varnish (
 
   # varnish config file
   file { 'varnish-conf':
-    ensure  => present,
+    ensure  => 'file',
     path    => $conf_file_path,
     owner   => 'root',
     group   => 'root',

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -19,10 +19,10 @@
 
 class varnish::service (
   $start                  = 'yes',
-  $systemd                = $::varnish::params::systemd,
-  $systemd_conf_path      = $::varnish::params::systemd_conf_path,
-  $vcl_reload_script      = $::varnish::params::vcl_reload_script
-) {
+  $systemd                = $varnish::params::systemd,
+  $systemd_conf_path      = $varnish::params::systemd_conf_path,
+  $vcl_reload_script      = $varnish::params::vcl_reload_script,
+) inherits varnish::params {
 
   # include install
   include ::varnish::install


### PR DESCRIPTION
Pull request #108 wasn't quite right. `$varnish::params::conf_file_path` isn't in scope and thus can't be used as a default value, that is without also adding `inherits varnish::params`. Without this change, I get the following error:

```
Error: Parameter path failed on File[varnish-conf]: File paths must be fully qualified, not 'varnish-conf' at /etc/puppet/ext_modules/varnish/manifests/init.pp:130
```