### PR TITLE
Remove unused variables

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,19 +32,11 @@ class varnish::params {
         $systemd = false
         $conf_file_path = '/etc/default/varnish'
         $default_version = '3'
-        
+
       }
     }
     default: {
       fail("Class['apache::params']: Unsupported osfamily: ${::osfamily}")
     }
-  }
-  $real_version = $::varnish::version ? {
-    /^(3|4).*/ => $::varnish::version,
-    default => $default_version,
-  }
-  $version = $real_version ? {
-    /4\..*/ => '4',
-    default => 3,
   }
 }


### PR DESCRIPTION
The `$varnish::params::version` and `$varnish::params::real_version` variables are unused. What's worse is that these variables reference the `$varnish::version` variable, which is not in scope:

```
Warning: Scope(Class[Varnish::Params]): Could not look up qualified variable '::varnish::version'; class ::varnish has not been evaluated
```