### PR TITLE
Quick hack to get the code working

### DIFF
--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -2,12 +2,18 @@
 define varnish::backend ( $host,
                           $port,
                           $probe = undef,
+                          $ensure = present,
                         ) {
 
   validate_re($title,'^[A-Za-z0-9_]*$', "Invalid characters in backend name $title. Only letters, numbers and underscore are allowed.")
   
   if (!is_ip_address($host)) {
     fail("Backend host $host is not an IP Address!")
+  }
+
+  concat { 
+    "${varnish::vcl::includedir}/backends.vcl":
+      ensure => $ensure,
   }
 
   concat::fragment { "$title-backend":

--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -11,11 +11,6 @@ define varnish::backend ( $host,
     fail("Backend host $host is not an IP Address!")
   }
 
-  concat { 
-    "${varnish::vcl::includedir}/backends.vcl":
-      ensure => $ensure,
-  }
-
   concat::fragment { "$title-backend":
     target => "${varnish::vcl::includedir}/backends.vcl",
     content => template('varnish/includes/backends.vcl.erb'),

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -5,6 +5,11 @@ define varnish::director ( $type = 'round-robin',
 
   validate_re($title,'^[A-Za-z0-9_]*$', "Invalid characters in director name $title. Only letters, numbers and underscore are allowed.")
 
+  concat {
+    "${varnish::vcl::includedir}/directors.vcl":
+      ensure => present, 
+  }
+
   concat::fragment { "$title-director":
     target => "${varnish::vcl::includedir}/directors.vcl",
     content => template('varnish/includes/directors.vcl.erb'),

--- a/manifests/probe.pp
+++ b/manifests/probe.pp
@@ -12,6 +12,11 @@ define varnish::probe ( $interval  = '5s',
   # parameters for probe
   $probe_params = [ 'interval', 'timeout', 'threshold', 'window', 'url', 'request' ]
 
+  concat {
+    "${varnish::vcl::includedir}/probes.vcl":
+      ensure => present,
+  }
+
   concat::fragment { "$title-probe":
     target => "${varnish::vcl::includedir}/probes.vcl",
     content => template('varnish/includes/probes.vcl.erb'),

--- a/manifests/shmlog.pp
+++ b/manifests/shmlog.pp
@@ -38,7 +38,7 @@ class varnish::shmlog (
     target  => '/etc/fstab',
     fstype  => 'tmpfs',
     device  => 'tmpfs',
-    options => 'defaults,noatime,size=128M',
+    options => 'defaults,noatime,size=256M',
     pass    => '0',
     dump    => '0',
     require => File['shmlog-dir'],

--- a/manifests/vcl.pp
+++ b/manifests/vcl.pp
@@ -160,6 +160,11 @@ class varnish::vcl (
   }
 
   # web application firewall
+  concat {
+    "${varnish::vcl::includedir}/waf.vcl":
+      ensure => present,
+  }
+
   concat::fragment { "waf":
     target => "${varnish::vcl::includedir}/waf.vcl",
     content => template('varnish/includes/waf.vcl.erb'),
@@ -189,6 +194,10 @@ class varnish::vcl (
     order => '02',
   }
   create_resources(varnish::selector,$selectors)
+  concat {
+    "${varnish::vcl::includedir}/backendselection.vcl":
+      ensure => present,
+  }
   concat::fragment { "selectors-footer":
     target => "${varnish::vcl::includedir}/backendselection.vcl",
     content => '} else {

--- a/manifests/vcl.pp
+++ b/manifests/vcl.pp
@@ -227,5 +227,10 @@ class varnish::vcl (
     purge => { hosts => $purgeips },
   } 
   $all_acls = merge($default_acls, $acls)
+  concat {
+    "${varnish::vcl::includedir}/acls.vcl":
+      ensure => present,
+  }
+ 
   create_resources(varnish::acl,$all_acls) 
 }

--- a/manifests/vcl.pp
+++ b/manifests/vcl.pp
@@ -175,14 +175,26 @@ class varnish::vcl (
  
   #Backends
   validate_hash($backends)
+  concat {
+    "${varnish::vcl::includedir}/backends.vcl":
+      ensure => present,
+  }
   create_resources(varnish::backend,$backends) 
 
   #Probes
   validate_hash($probes)
+  concat {
+    "${varnish::vcl::includedir}/probes.vcl":
+      ensure => present,
+  }
   create_resources(varnish::probe,$probes) 
   
   #Directors
   validate_hash($directors)
+  concat {
+    "${varnish::vcl::includedir}/directors.vcl":
+      ensure => present,
+  }
   create_resources(varnish::director,$directors)
 
   #Selectors
@@ -194,6 +206,7 @@ class varnish::vcl (
     order => '02',
   }
   create_resources(varnish::selector,$selectors)
+
   concat {
     "${varnish::vcl::includedir}/backendselection.vcl":
       ensure => present,


### PR DESCRIPTION
I got all complaints in the world from Puppet.

```

Error: Failed to apply catalog: uninitialized constant Puppet::Type::Concat_file
Did you mean?  Puppet::Confine
```


 ```
Warning: /Stage[main]/Varnish::Vcl/Varnish::Backend[default]/Concat::Fragment[default-backend]/Concat_fragment[default-backend]: Target Concat_file with path of /etc/varnish/includes/backends.vcl not found in the catalog

Warning: /Stage[main]/Varnish::Vcl/Varnish::Acl[blockedips]/Concat::Fragment[blockedips-acl]/Concat_fragment[blockedips-acl]: Target Concat_file with path of /etc/varnish/includes/acls.vcl not found in the catalog

Warning: /Stage[main]/Varnish::Vcl/Varnish::Acl[purge]/Concat::Fragment[purge-acl]/Concat_fragment[purge-acl]: Target Concat_file with path of /etc/varnish/includes/acls.vcl not found in the catalog

```

Somewhat stressed I hacked the files in this commit to at least get Puppet to create the configuration files. I'm using puppetlabs-concat and following the master release.
