### PR TITLE
Fix ordering of restart/reload

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -52,27 +52,28 @@ class varnish::service (
     default     => undef,
   }
 
-  exec {'restart-varnish':
+  exec { 'restart-varnish':
     command     => $restart_command,
     refreshonly => true,
-    require     => Service['varnish'],
+    before      => Service['varnish'],
+    require     => Package['varnish'],
   }
 
   if $systemd {
-      file {  $systemd_conf_path :
-        ensure => file,
-        content => template('varnish/varnish.service.erb'),
-        notify => Exec['Reload systemd'],
-        before => [Service['varnish'], Exec['restart-varnish']],
-        require => Package['varnish'],
-      }
+    file {  $systemd_conf_path :
+      ensure => file,
+      content => template('varnish/varnish.service.erb'),
+      notify => Exec['Reload systemd'],
+      before => [Service['varnish'], Exec['restart-varnish']],
+      require => Package['varnish'],
+    }
 
-      if (!defined(Exec['Reload systemd'])) {
-        exec {'Reload systemd':
-          command     => 'systemctl daemon-reload',
-          path        => ['/bin','/sbin','/usr/bin','/usr/sbin'],
-          refreshonly => true,
-        }
+    if (!defined(Exec['Reload systemd'])) {
+      exec {'Reload systemd':
+        command     => 'systemctl daemon-reload',
+        path        => ['/bin','/sbin','/usr/bin','/usr/sbin'],
+        refreshonly => true,
       }
+    }
   }
 }


### PR DESCRIPTION
`Exec['restart-varnish']` should always run before `Service['varnish']` (which triggers `service varnish reload`). Suppose that I update my VCL to use inline C code and also enable `vcc_allow_inline_c` at the same time. Currently, this will be evaluated as `File['/etc/varnish/default.vcl'] -> Service['varnish'] -> Exec['restart-varnish']`. The `Service['varnish']` resource, however, will fail with the following error message:

```
Error: /Stage[main]/Varnish::Service/Service[varnish]: Failed to call refresh: Could not restart Service[varnish]: Execution of '/etc/init.d/varnish reload' returned 1: * Reloading HTTP accelerator varnishd
Command failed with error code 106
Message from VCC-compiler:
Inline-C not allowed
```
