### PR TITLE
Ensure that the `varnish` package can be installed successfully when a custom `varnishncsa` format file is specified

### DIFF
--- a/manifests/ncsa.pp
+++ b/manifests/ncsa.pp
@@ -36,6 +36,7 @@ class varnish::ncsa (
     group   => 'root',
     content => template('varnish/varnishncsa-default.erb'),
     notify  => Service['varnishncsa'],
+    require => Package['varnish'],
   }
 
   $service_ensure = $enable ? {


### PR DESCRIPTION
On Ubuntu, the `varnish` package is distributed with a post-installation script which attempts to start the `varnish` and `varnishncsa` services:

```
if [ -x "/etc/init.d/varnish" ] || [ -e "/etc/init/varnish.conf" ]; then
    if [ ! -e "/etc/init/varnish.conf" ]; then
        update-rc.d varnish defaults >/dev/null
    fi
    invoke-rc.d varnish start || exit $?
fi
if [ -x "/etc/init.d/varnishlog" ] || [ -e "/etc/init/varnishlog.conf" ]; then
    if [ ! -e "/etc/init/varnishlog.conf" ]; then
        update-rc.d varnishlog defaults >/dev/null
    fi
    invoke-rc.d varnishlog start || exit $?
fi
if [ -x "/etc/init.d/varnishncsa" ] || [ -e "/etc/init/varnishncsa.conf" ]; then
    if [ ! -e "/etc/init/varnishncsa.conf" ]; then
        update-rc.d varnishncsa defaults >/dev/null
    fi
    invoke-rc.d varnishncsa start || exit $?
fi
```

As a result, we found that the following resource ordering caused problems: `File['/etc/default/varnishncsa'] -> Package['varnish'] -> File['/etc/varnish/ncsa-format']`. The problem here is that, when the post-installation script is executed, the `varnishncsa` format file does not yet exist. As such, the `varnishncsa` service fails to start and the package is left in a partially installed state (because the post-installation script failed). The easy way to fix this issue is to ensure that `File['/etc/default/varnishncsa']` is only created //after// the `varnish` package is installed. An alternative solution would be to move the `varnishncsa` format file out of `/etc/varnish` so that we could remove its dependency on `Package['varnish']`.
