### PR TITLE
Package vcl deps

### DIFF
--- a/manifests/vcl.pp
+++ b/manifests/vcl.pp
@@ -75,10 +75,8 @@ class varnish::vcl (
       group   => 'root',
       mode    => '0444',
       notify  => Service['varnish'],
-      require => [
-        File[$varnish::vcl::includedir],
-        Package['varnish'],
-      ],
+      require => File[$varnish::vcl::includedir],
+      before  => Exec['restart-varnish'],
     }
 
     concat::fragment { "${title}-header":

--- a/manifests/vcl.pp
+++ b/manifests/vcl.pp
@@ -75,7 +75,10 @@ class varnish::vcl (
       group   => 'root',
       mode    => '0444',
       notify  => Service['varnish'],
-      require => File[$varnish::vcl::includedir],
+      require => [
+        File[$varnish::vcl::includedir],
+        Package['varnish'],
+      ],
     }
 
     concat::fragment { "${title}-header":


### PR DESCRIPTION
There are two independent dependencies currently in the puppet module:
1. VCL files notify `Service['varnish']`
2. Changing `/etc/defaults/varnish` notifies `Exec['restart-varnish']`

Since there is no dependency between 1 and 2, restarting varnish can occur halfway between setting up all of the VCL files, resulting in varnish trying to start with an invalid configuration. To fix this, all the VCL files need to be put in place before restarting.
