### PR TITLE
Add support for backend.max_connections param

### DIFF
--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -2,6 +2,7 @@
 define varnish::backend(
   $host,
   $port,
+  $max_connections       = undef,
   $probe                 = undef,
   $connect_timeout       = undef,
   $first_byte_timeout    = undef,

--- a/templates/includes/backends.vcl.erb
+++ b/templates/includes/backends.vcl.erb
@@ -3,6 +3,7 @@ backend <%= @title -%> {
   .host = "<%= @host -%>";
   .port = "<%= @port -%>";
   <%- if @probe -%>  .probe = <%= @probe -%>; <%- end %>
+  <%- if @max_connections -%>  .max_connections = <%= @max_connections -%>; <%- end %>
   <%- if @connect_timeout -%>  .connect_timeout = <%= @connect_timeout -%>; <%- end %>
   <%- if @first_byte_timeout -%>  .first_byte_timeout = <%= @first_byte_timeout -%>; <%- end %>
   <%- if @between_bytes_timeout -%>  .between_bytes_timeout = <%= @between_bytes_timeout -%>; <%- end %>

--- a/templates/includes/backendselection4.vcl.erb
+++ b/templates/includes/backendselection4.vcl.erb
@@ -1,8 +1,8 @@
 if (<%= @condition -%>) {
     <%- if @movedto -%>
-  synth( 750, "<%= @movedto -%>" + req.url);  
+  synth( 750, "<%= @movedto -%>" + req.url);
     <%- else -%>
-  set req.backend_hint = <%= @director -%>;
+  set req.backend_hint = <%= @director -%>.backend();
       <%- if @rewrite -%>
   set req.http.x-host = <%= @rewrite -%>;
       <%- end -%>


### PR DESCRIPTION
Allow to set max_connections on a backend entry and 
fix _backend_hint = $backend.backend()_ for backendselection on varnish 4.0