### PR TITLE
use daemon opts in pre check

### DIFF
--- a/templates/varnish.service.erb
+++ b/templates/varnish.service.erb
@@ -27,7 +27,7 @@ EnvironmentFile=/etc/varnish/varnish.params
 Type=forking
 PIDFile=/var/run/varnish.pid
 PrivateTmp=true
-ExecStartPre=/usr/sbin/varnishd -C -f $VARNISH_VCL_CONF
+ExecStartPre=/usr/sbin/varnishd -C -f $VARNISH_VCL_CONF $DAEMON_OPTS
 ExecStart=/usr/sbin/varnishd -P /var/run/varnish.pid -f $VARNISH_VCL_CONF $DAEMON_OPTS
 ExecReload=<%= @vcl_reload_script %>
 


### PR DESCRIPTION
The configuration check in the `systemd` script should also be passed `$DAEMON_OPTS`. If it isn't, the configuration check may fail due to things like inline C.