### PR TITLE
move systemd service to its own manifest

### DIFF
--- a/manifests/ncsa.pp
+++ b/manifests/ncsa.pp
@@ -6,8 +6,6 @@ class varnish::ncsa (
   $systemd_conf_path  = $varnish::params::systemd_ncsa_conf_path,
 ) {
 
-  include varnish::service
-
   $log_format_file = '/etc/varnish/ncsa-format'
 
   # TODO: We should raise an error if a custom log format is specified when
@@ -56,6 +54,8 @@ class varnish::ncsa (
   }
 
   if $systemd {
+    include ::varnish::systemd
+
     file { $systemd_conf_path:
       ensure  => 'file',
       content => template('varnish/varnishncsa.service.erb'),

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -60,20 +60,14 @@ class varnish::service (
   }
 
   if $systemd {
+    include ::varnish::systemd
+
     file {  $systemd_conf_path :
       ensure => file,
       content => template('varnish/varnish.service.erb'),
       notify => Exec['Reload systemd'],
       before => [Service['varnish'], Exec['restart-varnish']],
       require => Package['varnish'],
-    }
-
-    if (!defined(Exec['Reload systemd'])) {
-      exec {'Reload systemd':
-        command     => 'systemctl daemon-reload',
-        path        => ['/bin','/sbin','/usr/bin','/usr/sbin'],
-        refreshonly => true,
-      }
     }
   }
 }

--- a/manifests/systemd.pp
+++ b/manifests/systemd.pp
@@ -1,0 +1,9 @@
+class varnish::systemd {
+  if (!defined(Exec['Reload systemd'])) {
+    exec {'Reload systemd':
+      command     => 'systemctl daemon-reload',
+      path        => ['/bin','/sbin','/usr/bin','/usr/sbin'],
+      refreshonly => true,
+    }
+  }
+}


### PR DESCRIPTION
This moves the systemd reload to its own file to remove the dependency between ncsa and service that was introduced in 1c8f19eeaea165251e2074d89f64a5419794649f. This allows the service `varnishncsa` to be managed without pulling in varnish.