### PR TITLE
Ubuntu systemd fixes

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,9 +23,12 @@ class varnish::params {
     }
     'Debian': {
       $vcl_reload_script = '/usr/share/varnish/reload-vcl'
-      if ($::service_provider == 'systemd') {
+      if ($::service_provider == 'systemd' or
+          ($::operatingsystem == 'Ubuntu' and 
+          versioncmp($::operatingsystemmajrelease, '15.10') > 0)) {
         $systemd = true
-        $systemd_conf_path = '/lib/systemd/system/varnish.service'
+        $systemd_conf_path = '/etc/systemd/system/varnish.service'
+        $systemd_ncsa_conf_path = '/etc/systemd/system/varnishncsa.service'
       } else {
         $systemd = false
       }


### PR DESCRIPTION
Puppet 3 doesn't detect whether systemd is being used correctly. This adds some extra checks for Ubuntu to detect systemd.

The preferred way on systemd to override unit files is to place them in `/etc/systemd` rather than overwriting package provided files. So this also moves the unit file paths.