### PR TITLE
add name variable to varnish module

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,6 +74,7 @@ class varnish (
   $manage_firewall              = false,
   $varnish_conf_template        = 'varnish/varnish-conf.erb',
   $varnish_identity             = undef,
+  $varnish_name                 = undef,
   $additional_parameters        = {},
   $additional_storages          = {},
   $conf_file_path               = $varnish::params::conf_file_path,

--- a/templates/varnish-conf.erb
+++ b/templates/varnish-conf.erb
@@ -108,6 +108,9 @@ DAEMON_OPTS="-a <%= scope.lookupvar('varnish_listen_address') %>:<%= scope.looku
 <% @additional_storages.each do |name,storage| -%>
              -s <%= name %>=<%= storage %> \
 <% end -%>
+<% if @varnish_name -%>
+             -n <%= @varnish_name %> \
+<% end -%>
 <% if scope.function_versioncmp([@real_version, '4']) >= 0 -%>
              -p thread_pool_min=<%= scope.lookupvar('varnish_min_threads') %> \
              -p thread_pool_max=<%= scope.lookupvar('varnish_max_threads') %> \
@@ -115,5 +118,6 @@ DAEMON_OPTS="-a <%= scope.lookupvar('varnish_listen_address') %>:<%= scope.looku
 <% else -%>
              -w <%= scope.lookupvar('varnish_min_threads') %>,<%= scope.lookupvar('varnish_max_threads') %>,<%= scope.lookupvar('varnish_thread_timeout') %>"
 <% end -%>
+
 
 


### PR DESCRIPTION
The main reason for this variable is here from the man page:

>       -n name
> Specify the name for this instance.  Amongst other things, this name is used to construct the name of the directory in which varnishd keeps temporary files and persistent state. If the specified name begins with a forward slash, it is interpreted as the absolute path to the directory which should be used for this purpose.

This is very helpful when determining the folder for the _.vsm file.
