### PR TITLE
Don't create `waf.vcl` if `$enable_waf` is `false`

### DIFF
--- a/manifests/vcl.pp
+++ b/manifests/vcl.pp
@@ -114,16 +114,20 @@ class varnish::vcl (
       recurse => true,
       require => Package['varnish'],
     }
-    $includefiles = ['probes', 'backends', 'directors', 'acls', 'backendselection', 'waf']
+    $includefiles = ['probes', 'backends', 'directors', 'acls', 'backendselection']
 
     varnish::vcl::includefile { $includefiles: }
 
     # web application firewall
-    concat::fragment { 'waf':
-      target  => "${varnish::vcl::includedir}/waf.vcl",
-      content => template('varnish/includes/waf.vcl.erb'),
-      order   => '02',
-      notify  => Service['varnish'],
+    if $enable_waf {
+      varnish::vcl::includefile { 'waf': }
+
+      concat::fragment { 'waf':
+        target  => "${varnish::vcl::includedir}/waf.vcl",
+        content => template('varnish/includes/waf.vcl.erb'),
+        order   => '02',
+        notify  => Service['varnish'],
+      }
     }
 
     #Create resources


### PR DESCRIPTION
Currently `/etc/varnish/includes/waf.vcl` is created unconditionally, even if `$enable_waf` is set to `false`.