### PR TITLE
Allow specifying selector ordering

### DIFF
--- a/manifests/selector.pp
+++ b/manifests/selector.pp
@@ -6,6 +6,7 @@ define varnish::selector(
   $rewrite = undef,
   $newurl = undef,
   $movedto = undef,
+  $order = 10,
 ) {
   if versioncmp($::varnish::real_version, '4') >= 0 {
     $template_selector = 'varnish/includes/backendselection4.vcl.erb'
@@ -22,7 +23,7 @@ define varnish::selector(
   concat::fragment { "${title}-selector":
     target  => "${varnish::vcl::includedir}/backendselection.vcl",
     content => template($template_selector),
-    order   => '03',
+    order   => $order,
     notify  => Service['varnish'],
   }
 

--- a/spec/defines/selector_spec.rb
+++ b/spec/defines/selector_spec.rb
@@ -1,0 +1,110 @@
+require 'spec_helper'
+
+describe 'varnish::selector', :type => :define do
+  let(:facts) do
+    {
+      architecture: 'x86_64',
+      lsbdistcodename: 'xenial',
+      lsbdistid: 'Debian',
+      operatingsystem: 'Ubuntu',
+      operatingsystemmajrelease: '16.04',
+      operatingsystemrelease: '16.04',
+      osfamily: 'Debian',
+      puppetversion: Puppet.version,
+      selinux: false,
+      service_provider: 'systemd',
+    }
+  end
+  let(:pre_condition) do
+    [
+      "class { 'varnish': version => #{varnish_version.to_s.to_json} }",
+      'include varnish::vcl',
+    ]
+  end
+
+  let(:title) { 'foobar' }
+  let(:params) do
+    {
+      condition: 'req.http.Host == "www.foobar.com"'
+    }
+  end
+  let(:varnish_version) { 5.0 }
+
+  context 'with varnish::version => 3.0' do
+    let(:varnish_version) { 3.0 }
+
+    it { is_expected.to compile.with_all_deps }
+    it do
+      is_expected.to contain_concat__fragment("#{title}-selector")
+        .that_notifies('Service[varnish]')
+        .with(
+          target: '/etc/varnish/includes/backendselection.vcl',
+          order: 10,
+        )
+    end
+
+    context 'with director' do
+      it { is_expected.to contain_concat__fragment("#{title}-selector").with_content(/^  set req\.backend = #{Regexp.escape title};$/) }
+    end
+  end
+
+  context 'with varnish::version => 4.1' do
+    let(:varnish_version) { 4.1 }
+
+    it { is_expected.to compile.with_all_deps }
+    it do
+      is_expected.to contain_concat__fragment("#{title}-selector")
+        .that_notifies('Service[varnish]')
+        .with(
+          target: '/etc/varnish/includes/backendselection.vcl',
+          order: 10,
+        )
+    end
+
+    context 'with backend' do
+      let(:params) { super().merge(:backend => 'backend01') }
+
+      it { is_expected.to contain_concat__fragment("#{title}-selector").with_content(/^  set req\.backend_hint = #{Regexp.escape params[:backend]};$/) }
+    end
+
+    context 'with director' do
+      it { is_expected.to contain_concat__fragment("#{title}-selector").with_content(/^  set req\.backend_hint = #{Regexp.escape title}\.backend\(\);$/) }
+    end
+  end
+
+  context 'with varnish::version => 5.0' do
+    let(:varnish_version) { 5.0 }
+
+    it { is_expected.to compile.with_all_deps }
+    it do
+      is_expected.to contain_concat__fragment("#{title}-selector")
+        .that_notifies('Service[varnish]')
+        .with(
+          target: '/etc/varnish/includes/backendselection.vcl',
+          order: 10,
+        )
+    end
+
+    context 'with backend' do
+      let(:params) { super().merge(:backend => 'backend01') }
+
+      it { is_expected.to contain_concat__fragment("#{title}-selector").with_content(/^  set req\.backend_hint = #{Regexp.escape params[:backend]};$/) }
+    end
+
+    context 'with director' do
+      it { is_expected.to contain_concat__fragment("#{title}-selector").with_content(/^  set req\.backend_hint = #{Regexp.escape title}\.backend\(\);$/) }
+    end
+  end
+
+  context 'with rewrite' do
+    let(:params) { super().merge(:rewrite => '"foobar.com"') }
+
+    it { is_expected.to contain_concat__fragment("#{title}-selector").with_content(/^  set req\.http\.x-host = #{Regexp.escape params[:rewrite]};$/) }
+  end
+
+  context 'with order' do
+    let(:params) { super().merge(:order => 20) }
+
+    it { is_expected.to contain_concat__fragment("#{title}-selector").with_order(params[:order]) }
+  end
+end


### PR DESCRIPTION
Currently it is not possible to specify an order for Varnish selectors. This means that if multiple selectors satisfy a request then it is not possible to specify which selector "wins". This pull request adds a `$order` parameter to `varnish::selector` to fix this. I have also added some basic RSpec test coverage.