### PR TITLE
Fix apt key source

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -45,8 +45,10 @@ class varnish::repo (
         apt::source { 'varnish':
           location   => "${repo_base_url}/${repo_distro}",
           repos      => "varnish-${varnish::real_version}",
-          key        => 'E98C6BBBA1CBC5C3EB2DF21C60E7C096C4DEFFEB',
-          key_source => 'http://repo.varnish-cache.org/debian/GPG-key.txt',
+          key        => {
+            id => 'E98C6BBBA1CBC5C3EB2DF21C60E7C096C4DEFFEB',
+            source => 'http://repo.varnish-cache.org/debian/GPG-key.txt',
+          },
         }
       }
       default: {


### PR DESCRIPTION
This fixes a deprecation in the apt module. They `apt::source` parameter `key` has been changed and `key_source` was removed, and is now replaced by `key` being a hash.