### PR TITLE
[Issue #140] Add "enable" parameter for varnish service

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -19,6 +19,7 @@
 
 class varnish::service (
   $start                  = 'yes',
+  $enable                 = true,
   $systemd                = $varnish::params::systemd,
   $systemd_conf_path      = $varnish::params::systemd_conf_path,
   $vcl_reload_script      = $varnish::params::vcl_reload_script,
@@ -42,6 +43,7 @@ class varnish::service (
 
   service {'varnish':
     ensure  => $service_state,
+    enable  => $enable,
     restart => $reload_cmd,
     require => Package['varnish'],
   }


### PR DESCRIPTION
Class `varnish::service` wasn't managing varnish service behaviour at boot. This adds it.