### PR TITLE
[Issue #145] Add custom fact to check init system

### DIFF
--- a/lib/facter/init_system.rb
+++ b/lib/facter/init_system.rb
@@ -15,8 +15,10 @@ Facter.add(:init_system) do
           pkg_exec = Facter::Core::Execution::exec("dpkg-query -S #{path_exec}").split(' ')[0]
         when 'RedHat'
           pkg_exec = Facter::Core::Execution::exec("rpm -qf #{path_exec}").split('-')[0]
+        else
+          pkg_exec = 'unknown'
         end
-        pkg_exec.downcase[/systemd|upstart|init/]
+        pkg_exec.downcase[/systemd|upstart|init|unknown/]
       end
     end
   end

--- a/lib/facter/init_system.rb
+++ b/lib/facter/init_system.rb
@@ -1,25 +1,37 @@
 Facter.add(:init_system) do
   confine :kernel => 'Linux'
   setcode do
+
+    # Active init system process has PID 1
     proc_1 = Facter::Core::Execution::exec('ps --no-headers -p 1').split(' ')[-1]
+
+    # A PID 1 process called `init` can be a link to systemd or upstart
     unless proc_1 == 'init'
       proc_1
     else
       path_exec = Facter::Core::Execution::exec("ls -l $(which #{proc_1})").split(' ')[-1]
       file_exec = path_exec.split('/')[-1]
+
+      # An executable called `init` can be a link to systemd or upstart
       unless file_exec == 'init'
         file_exec
       else
+
+        # Check package which provided running init system executable
         case Facter.value(:osfamily)
         when 'Debian', 'Ubuntu'
           pkg_exec = Facter::Core::Execution::exec("dpkg-query -S #{path_exec}").split(' ')[0]
         when 'RedHat'
           pkg_exec = Facter::Core::Execution::exec("rpm -qf #{path_exec}").split('-')[0]
+        # TODO: add similar checks for other distros
         else
           pkg_exec = 'unknown'
         end
         pkg_exec.downcase[/systemd|upstart|init|unknown/]
+
       end
+
     end
+
   end
 end

--- a/lib/facter/init_system.rb
+++ b/lib/facter/init_system.rb
@@ -6,7 +6,18 @@ Facter.add(:init_system) do
       proc_1
     else
       path_exec = Facter::Core::Execution::exec("ls -l $(which #{proc_1})").split(' ')[-1]
-      path_exec.split('/')[-1]
+      file_exec = path_exec.split('/')[-1]
+      unless file_exec == 'init'
+        file_exec
+      else
+        case Facter.value(:osfamily)
+        when 'Debian', 'Ubuntu'
+          pkg_exec = Facter::Core::Execution::exec("dpkg-query -S #{path_exec}").split(' ')[0]
+        when 'RedHat'
+          pkg_exec = Facter::Core::Execution::exec("rpm -qf #{path_exec}").split('-')[0]
+        end
+        pkg_exec.downcase[/systemd|upstart|init/]
+      end
     end
   end
 end

--- a/lib/facter/init_system.rb
+++ b/lib/facter/init_system.rb
@@ -1,0 +1,6 @@
+Facter.add(:init_system) do
+  confine :kernel => 'Linux'
+  setcode do
+    Facter::Core::Execution::exec('ps --no-headers -p 1').split(' ')[-1]
+  end
+end

--- a/lib/facter/init_system.rb
+++ b/lib/facter/init_system.rb
@@ -2,7 +2,7 @@ Facter.add(:init_system) do
   confine :kernel => 'Linux'
   setcode do
     proc_1 = Facter::Core::Execution::exec('ps --no-headers -p 1').split(' ')[-1]
-    if proc_1 != 'init'
+    unless proc_1 == 'init'
       proc_1
     else
       path_exec = Facter::Core::Execution::exec("ls -l $(which #{proc_1})").split(' ')[-1]

--- a/lib/facter/init_system.rb
+++ b/lib/facter/init_system.rb
@@ -1,6 +1,12 @@
 Facter.add(:init_system) do
   confine :kernel => 'Linux'
   setcode do
-    Facter::Core::Execution::exec('ps --no-headers -p 1').split(' ')[-1]
+    proc_1 = Facter::Core::Execution::exec('ps --no-headers -p 1').split(' ')[-1]
+    if proc_1 != 'init'
+      proc_1
+    else
+      path_exec = Facter::Core::Execution::exec("ls -l $(which #{proc_1})").split(' ')[-1]
+      path_exec.split('/')[-1]
+    end
   end
 end

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,7 @@ class varnish::params {
       $default_version = '3.0'
       $add_repo = true
       $vcl_reload_script = '/usr/sbin/varnish_reload_vcl'
-      if ($::service_provider == 'systemd') {
+      if ($::init_system == 'systemd') {
         $systemd = true
         $systemd_conf_path = '/usr/lib/systemd/system/varnish.service'
         $systemd_ncsa_conf_path = undef
@@ -26,7 +26,7 @@ class varnish::params {
     }
     'Debian': {
       $vcl_reload_script = '/usr/share/varnish/reload-vcl'
-      if ($::service_provider == 'systemd' or
+      if ($::init_system == 'systemd' or
           ($::operatingsystem == 'Ubuntu' and
           versioncmp($::operatingsystemmajrelease, '15.10') > 0)) {
         $systemd = true

--- a/spec/defines/selector_spec.rb
+++ b/spec/defines/selector_spec.rb
@@ -12,7 +12,7 @@ describe 'varnish::selector', :type => :define do
       osfamily: 'Debian',
       puppetversion: Puppet.version,
       selinux: false,
-      service_provider: 'systemd',
+      init_system: 'systemd',
     }
   end
   let(:pre_condition) do


### PR DESCRIPTION
Class `varnish::params` uses stdlib fact `service_provider` to determine OS's init system. But, according to stlib [docs](https://github.com/puppetlabs/puppetlabs-stdlib#service_provider), this fact doesn't seem to fit the task.

This change adds the custom fact `init_system`, which determines the init system actually running.