### PR TITLE
Perform gpg check on the repodata but not on the rpm

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -35,12 +35,13 @@ class varnish::repo (
     case $::osfamily {
       redhat: {
         yumrepo { 'varnish':
-          descr    => 'varnish',
-          enabled  => '1',
-          gpgcheck => '1',
-          gpgkey   => "${repo_base_url}/varnishcache/varnish${$repo_version}/gpgkey",
-          priority => '1',
-          baseurl  => "${repo_base_url}/varnishcache/varnish${repo_version}/${repo_distro}/${osver}/\$basearch",
+          descr         => 'varnish',
+          enabled       => '1',
+          gpgcheck      => '0',
+          repo_gpgcheck => '1',
+          gpgkey        => "${repo_base_url}/varnishcache/varnish${$repo_version}/gpgkey",
+          priority      => '1',
+          baseurl       => "${repo_base_url}/varnishcache/varnish${repo_version}/${repo_distro}/${osver}/\$basearch",
         }
       }
 


### PR DESCRIPTION
Gpg check for the rpm were failing. Gpg check for the repo metadata is working.

```
Error: Execution of '/bin/yum -d 0 -e 0 -y install varnish' returned 1: warning: /var/cache/yum/x86_64/7/varnish/packages/varnish-4.1.8-1.el7.x86_64.rpm: Header V4 RSA/SHA1 Signature, key ID c4deffeb: NOKEY                                                                                        
                                                                                                                                                   
                                                                                                                                                   
The GPG keys listed for the "varnish" repository are already installed but they are not correct for this package.                                  
Check that the correct key URLs are configured for this repository.                                                                                
                                                                                                                                                   
                                                                                                                                                   
 Failing package is: varnish-4.1.8-1.el7.x86_64                                                                                                    
 GPG Keys are configured as: https://packagecloud.io/varnishcache/varnish41/gpgkey
```