### PR TITLE
[Issue #5] Add initial and expected_response to probe

### DIFF
--- a/manifests/probe.pp
+++ b/manifests/probe.pp
@@ -1,17 +1,19 @@
 #probe.pp
 define varnish::probe(
-  $interval  = '5s',
-  $timeout   = '5s',
-  $threshold = '3',
-  $window    = '8',
-  $url       = undef,
-  $request   = undef
+  $initial           = '3',
+  $interval          = '5s',
+  $timeout           = '5s',
+  $threshold         = '3',
+  $window            = '8',
+  $expected_response = '200',
+  $url               = undef,
+  $request           = undef
 ) {
 
   validate_re($title,'^[A-Za-z0-9_]*$', "Invalid characters in probe name ${title}. Only letters, numbers and underscore are allowed.")
 
   # parameters for probe
-  $probe_params = [ 'interval', 'timeout', 'threshold', 'window', 'url', 'request' ]
+  $probe_params = [ 'initial', 'interval', 'timeout', 'threshold', 'window', 'expected_response', 'url', 'request' ]
 
   concat::fragment { "${title}-probe":
     target  => "${varnish::vcl::includedir}/probes.vcl",


### PR DESCRIPTION
Need `expected_response` for a CAS-wrapped application that sends 302 for practically everything that hasn't been signed into CAS