### PR TITLE
Add support to use a custom package name

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,9 @@
 #                 '4.0' and '4.1')
 # add_repo      - if set to false (defaults to true), the yum/apt repo is not added
 #
+# package_name  - the name of the package that should be installed
+#                 default value: varnish
+#
 # === Default values
 # Set to Varnish default values
 # With an exception to
@@ -75,6 +78,7 @@ class varnish (
   $varnish_conf_template        = 'varnish/varnish-conf.erb',
   $varnish_identity             = undef,
   $varnish_name                 = undef,
+  $package_name                 = 'varnish',
   $additional_parameters        = {},
   $additional_storages          = {},
   $conf_file_path               = $varnish::params::conf_file_path,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -31,5 +31,6 @@ class varnish::install (
   # Varnish package
   package { 'varnish':
     ensure => $varnish::ensure,
+    name   => $varnish::package_name,
   }
 }


### PR DESCRIPTION
In certain scenarios it might make sense to use a different package name
than the hardcoded 'varnish' package name (eg. when using varnish-plus)

This commit introduces a new parameter $package_name which defaults to
'varnish'. The parameter is used in the install.pp class to set the name
of the package to install. Since the default is set to 'varnish', this
change does not break any existing setups.