### PR TITLE
Varnish 6.0 repository

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -65,6 +65,9 @@ class varnish::repo (
             '52': {
               $key_id = '91CFD5635A1A5FAC0662BEDD2E9BA3FE86BE909D'
             }
+            '60': {
+              $key_id = '7C5B46721AF00FD57E68E6E8D2605BF74E8B9DBA'
+            }
             default: {
               fail("Repo version ${repo_version} not supported")
             }


### PR DESCRIPTION
This is the bare minimum necessary to be able to install Varnish 6.0 with this module.

I have not tested the configuration portions of Varnish just yet. And there is also the fact that more intrusive changes will be necessary to support 6.0 LTS as the package versions are the same but the repository is `varnish60lts` so the current logic to compute the package repository name will not work. But I didn't want to create a bigger diff