### PR TITLE
Manage storage directory user

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -158,6 +158,9 @@ class varnish (
   file { 'storage-dir':
     ensure  => directory,
     path    => $varnish_storage_dir,
+    owner   => $varnish_user,
+    group   => $varnish_group,
+    mode    => '0755',
     require => Package['varnish'],
   }
 }


### PR DESCRIPTION
Manage the owner, group and mode of the storage directory. Varnish needs to be able to write to this directory, so it should be owned by `$varnish_user`.